### PR TITLE
更好的假人背包快速移动物品

### DIFF
--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/APAccessor.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/APAccessor.java
@@ -1,9 +1,6 @@
 package dev.dubhe.gugle.carpet.mixin;
 
-import carpet.fakes.ServerPlayerInterface;
 import carpet.helpers.EntityPlayerActionPack;
-import com.google.gson.JsonObject;
-import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -11,18 +8,18 @@ import java.util.Map;
 
 @Mixin(EntityPlayerActionPack.class)
 public interface APAccessor {
-    @Accessor
+    @Accessor(remap = false)
     Map<EntityPlayerActionPack.ActionType, EntityPlayerActionPack.Action> getActions();
 
-    @Accessor
+    @Accessor(remap = false)
     boolean getSneaking();
 
-    @Accessor
+    @Accessor(remap = false)
     boolean getSprinting();
 
-    @Accessor
+    @Accessor(remap = false)
     float getForward();
 
-    @Accessor
+    @Accessor(remap = false)
     float getStrafing();
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/CommandsMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/CommandsMixin.java
@@ -18,7 +18,7 @@ public class CommandsMixin {
     @Final
     private CommandDispatcher<CommandSourceStack> dispatcher;
 
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/CommandDispatcher;setConsumer(Lcom/mojang/brigadier/ResultConsumer;)V"))
+    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/CommandDispatcher;setConsumer(Lcom/mojang/brigadier/ResultConsumer;)V"), remap = false)
     private void register(Commands.CommandSelection commandSelection, CommandBuildContext commandBuildContext, CallbackInfo ci) {
         //BotCommand.register(this.dispatcher);
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/PlayerMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/PlayerMixin.java
@@ -6,6 +6,7 @@ import dev.dubhe.gugle.carpet.GcaSetting;
 import dev.dubhe.gugle.carpet.api.tools.text.ComponentTranslate;
 import dev.dubhe.gugle.carpet.tools.FakePlayerEnderChestContainer;
 import dev.dubhe.gugle.carpet.tools.FakePlayerInventoryContainer;
+import dev.dubhe.gugle.carpet.tools.FakePlayerInventoryMenu;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -61,7 +62,7 @@ abstract class PlayerMixin {
             }
         } else if (GcaSetting.openFakePlayerInventory) {
             provider = new SimpleMenuProvider(
-                (i, inventory, p) -> ChestMenu.sixRows(
+                (i, inventory, p) -> new FakePlayerInventoryMenu(
                     i, inventory,
                     GcaExtension.fakePlayerInventoryContainerMap.get(fakePlayer).getKey()
                 ),

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/FakePlayerInventoryMenu.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/FakePlayerInventoryMenu.java
@@ -1,0 +1,67 @@
+package dev.dubhe.gugle.carpet.tools;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class FakePlayerInventoryMenu extends ChestMenu {
+    public FakePlayerInventoryMenu(int i, Inventory inventory, Container container) {
+        super(MenuType.GENERIC_9x6, i, inventory, container, 6);
+    }
+
+    @Override
+    public @NotNull ItemStack quickMoveStack(@NotNull Player player, int slotIndex) {
+        ItemStack remainingItem = ItemStack.EMPTY;
+        Slot slot = this.slots.get(slotIndex);
+        if (slot.hasItem()) {
+            ItemStack slotStack = slot.getItem();
+            remainingItem = slotStack.copy();
+            if (slotIndex < 54) {
+                if (!this.moveItemStackTo(slotStack, 54, this.slots.size(), true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (slotStack.getItem() instanceof ArmorItem armorItem) {
+                // 如果是盔甲，移动的盔甲槽
+                int ordinal = armorItem.getType().ordinal();
+                if (moveToArmor(slotStack, ordinal) || moveToInventory(slotStack)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (slotStack.isEdible()) {
+                // 如果是食物，移动到副手
+                if (moveToOffHand(slotStack) || (moveToInventory(slotStack))) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (moveToInventory(slotStack)) {
+                // 其它物品移动的物品栏中
+                return ItemStack.EMPTY;
+            }
+            if (slotStack.isEmpty()) {
+                slot.setByPlayer(ItemStack.EMPTY);
+            } else {
+                slot.setChanged();
+            }
+        }
+        return remainingItem;
+    }
+
+    // 移动到副手
+    private boolean moveToOffHand(ItemStack slotStack) {
+        return this.moveItemStackTo(slotStack, 7, 8, false);
+    }
+
+    // 移动到盔甲槽
+    private boolean moveToArmor(ItemStack slotStack, int ordinal) {
+        return this.moveItemStackTo(slotStack, ordinal + 1, ordinal + 2, false);
+    }
+
+    // 将物品移动的物品栏
+    private boolean moveToInventory(ItemStack slotStack) {
+        return !this.moveItemStackTo(slotStack, 18, 54, false);
+    }
+}


### PR DESCRIPTION
更改了在假人背包界面按Shift键向假人背包内快速移动物品的逻辑：
1. 如果是盔甲，默认移动到假人的盔甲槽
2. 如果是食物，默认移动到副手槽位
3. 其它物品默认移动到物品栏槽位