### PR TITLE
保持/here命令与Carpet AMS Addition的兼容性

### DIFF
--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -90,7 +90,8 @@ public class GcaSetting {
     @Rule(
         categories = {GCA, EXPERIMENTAL, BOT, COMMAND},
         options = {"ops", "0", "1", "2", "3", "4", "true", "false"},
-        validators = Validators.CommandLevel.class
+        validators = Validators.CommandLevel.class,
+        conditions = GcaValidators.CarpetAmsAdditionLoaded.class
     )
     public static String commandHere = "ops";
 

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaValidators.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaValidators.java
@@ -1,13 +1,17 @@
 package dev.dubhe.gugle.carpet;
 
 import carpet.api.settings.CarpetRule;
+import carpet.api.settings.Rule;
 import carpet.api.settings.Validator;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.commands.CommandSourceStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class GcaValidators {
+    public static final boolean CARPET_AMS_ADDITION = FabricLoader.getInstance().isModLoaded("carpet-ams-addition");
+
     public static class EnderChest extends Validator<String> {
         public static final List<String> OPTIONS = List.of("true", "false", "ender_chest");
 
@@ -18,6 +22,13 @@ public class GcaValidators {
 
         public String description() {
             return "Can be limited to 'ender_chest' for use EnderChest open only, true/false for open directly/unable";
+        }
+    }
+
+    public static class CarpetAmsAdditionLoaded implements Rule.Condition {
+        @Override
+        public boolean shouldRegister() {
+            return !CARPET_AMS_ADDITION;
         }
     }
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/commands/HereCommand.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/commands/HereCommand.java
@@ -4,6 +4,7 @@ import carpet.utils.CommandHelper;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import dev.dubhe.gugle.carpet.GcaSetting;
+import dev.dubhe.gugle.carpet.GcaValidators;
 import dev.dubhe.gugle.carpet.tools.PosUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -14,6 +15,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class HereCommand {
     public static void register(@NotNull CommandDispatcher<CommandSourceStack> dispatcher) {
+        if (GcaValidators.CARPET_AMS_ADDITION) {
+            return;
+        }
         dispatcher.register(
             Commands.literal("here")
                 .requires(stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandHere))


### PR DESCRIPTION
同时安装`Carpet AMS Addition`时不注册`/here`命令
fix #92 