### PR TITLE
fix(betterQuickCrafting): 修复高版本快速合成数组越界问题

### DIFF
--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
@@ -7,8 +7,16 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 //#if MC>=12102
+//$$ import org.spongepowered.asm.mixin.Final;
+//$$ import org.spongepowered.asm.mixin.Mixin;
+//$$ import org.spongepowered.asm.mixin.Shadow;
 //$$ import org.spongepowered.asm.mixin.injection.Inject;
+//$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+//$$ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+//$$ import net.minecraft.world.entity.player.StackedItemContents;
+//$$ import net.minecraft.world.item.crafting.RecipeHolder;
+//$$ import com.llamalad7.mixinextras.sugar.Local;
 //#elseif MC>=12100
 import net.minecraft.world.item.crafting.RecipeHolder;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -28,9 +36,29 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 @Mixin(ServerPlaceRecipe.class)
 abstract class ServerPlaceRecipeMixin {
     //#if MC>=12102
+    //$$ @Final
+    //$$ @Shadow
+    //$$ private boolean useMaxItems;
+    //$$
     //$$ @Inject(method = "calculateAmountToCraft", at = @At("RETURN"), cancellable = true)
     //$$ private void calculateAmountToCraft(int i, boolean bl, CallbackInfoReturnable<Integer> cir) {
-    //$$     if (GcaSetting.betterQuickCrafting) cir.setReturnValue(cir.getReturnValueI() - 1);
+    //$$     if (GcaSetting.betterQuickCrafting && this.useMaxItems) cir.setReturnValue(cir.getReturnValueI() - 1);
+    //$$ }
+    //$$
+    //$$ @Inject(
+    //$$         method = "placeRecipe(Lnet/minecraft/world/item/crafting/RecipeHolder;Lnet/minecraft/world/entity/player/StackedItemContents;)V",
+    //$$         at = @At(
+    //$$                 value = "INVOKE",
+    //$$                 target = "Lnet/minecraft/world/entity/player/StackedItemContents;canCraft(Lnet/minecraft/world/item/crafting/Recipe;ILnet/minecraft/world/entity/player/StackedContents$Output;)Z",
+    //$$                 shift = At.Shift.BEFORE
+    //$$         ),
+    //$$         cancellable = true
+    //$$ )
+    //$$ private void checkCraftAmount(
+    //$$         RecipeHolder<?> recipeHolder, StackedItemContents stackedItemContents, CallbackInfo ci, @Local(ordinal = 1) int j
+    //$$ ) {
+    //$$     if (j <= 0) ci.cancel();
+    //$$
     //$$ }
     //#elseif MC>=12100
     @WrapOperation(method = "handleRecipeClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/StackedContents;getBiggestCraftableStack(Lnet/minecraft/world/item/crafting/RecipeHolder;Lit/unimi/dsi/fastutil/ints/IntList;)I"))


### PR DESCRIPTION
ServerPlaceRecipe里面如果可合成数量为0还会继续向后执行，在后面会有一些神秘的处理过程，导致后面产生神秘的数组越界

这里只是简单的处理了一下：
1. 区分shift和非shift情况
2. 做了一下提前的0返回

只是自用的临时修复，100%准确的原因还要细找