### PR TITLE
修改项目依赖关系, 使用更好的preprocess方案

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ preprocess {
 
     mc12001.link(mc12101, null)
     mc12102.link(mc12101, null)
-    mc12103.link(mc12101, null)
-    mc12104.link(mc12101, null)
-    mc12105.link(mc12101, null)
-    mc12107.link(mc12101, null)
-    mc12110.link(mc12101, null)
+    mc12103.link(mc12102, null)
+    mc12104.link(mc12103, null)
+    mc12105.link(mc12104, null)
+    mc12107.link(mc12105, null)
+    mc12110.link(mc12107, null)
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
@@ -6,71 +6,18 @@ import net.minecraft.recipebook.ServerPlaceRecipe;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-//#if MC>=12102
-//$$ import org.spongepowered.asm.mixin.Final;
-//$$ import org.spongepowered.asm.mixin.Mixin;
-//$$ import org.spongepowered.asm.mixin.Shadow;
-//$$ import org.spongepowered.asm.mixin.injection.Inject;
-//$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-//$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-//$$ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-//$$ import net.minecraft.world.entity.player.StackedItemContents;
-//$$ import net.minecraft.world.item.crafting.RecipeHolder;
-//$$ import com.llamalad7.mixinextras.sugar.Local;
-//#elseif MC>=12100
 import net.minecraft.world.item.crafting.RecipeHolder;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.world.entity.player.StackedContents;
 import org.jetbrains.annotations.NotNull;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-//#else
-//$$ import net.minecraft.world.item.crafting.Recipe;
-//$$ import it.unimi.dsi.fastutil.ints.IntList;
-//$$ import net.minecraft.world.entity.player.StackedContents;
-//$$ import org.jetbrains.annotations.NotNull;
-//$$ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-//$$ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-//#endif
 
 @Mixin(ServerPlaceRecipe.class)
 abstract class ServerPlaceRecipeMixin {
-    //#if MC>=12102
-    //$$ @Final
-    //$$ @Shadow
-    //$$ private boolean useMaxItems;
-    //$$
-    //$$ @Inject(method = "calculateAmountToCraft", at = @At("RETURN"), cancellable = true)
-    //$$ private void calculateAmountToCraft(int i, boolean bl, CallbackInfoReturnable<Integer> cir) {
-    //$$     if (GcaSetting.betterQuickCrafting && this.useMaxItems) cir.setReturnValue(cir.getReturnValueI() - 1);
-    //$$ }
-    //$$
-    //$$ @Inject(
-    //$$         method = "placeRecipe(Lnet/minecraft/world/item/crafting/RecipeHolder;Lnet/minecraft/world/entity/player/StackedItemContents;)V",
-    //$$         at = @At(
-    //$$                 value = "INVOKE",
-    //$$                 target = "Lnet/minecraft/world/entity/player/StackedItemContents;canCraft(Lnet/minecraft/world/item/crafting/Recipe;ILnet/minecraft/world/entity/player/StackedContents$Output;)Z",
-    //$$                 shift = At.Shift.BEFORE
-    //$$         ),
-    //$$         cancellable = true
-    //$$ )
-    //$$ private void checkCraftAmount(
-    //$$         RecipeHolder<?> recipeHolder, StackedItemContents stackedItemContents, CallbackInfo ci, @Local(ordinal = 1) int j
-    //$$ ) {
-    //$$     if (j <= 0) ci.cancel();
-    //$$
-    //$$ }
-    //#elseif MC>=12100
     @WrapOperation(method = "handleRecipeClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/StackedContents;getBiggestCraftableStack(Lnet/minecraft/world/item/crafting/RecipeHolder;Lit/unimi/dsi/fastutil/ints/IntList;)I"))
     private int handleRecipeClicked(StackedContents instance, RecipeHolder<?> recipeHolder, IntList intList, @NotNull Operation<Integer> original) {
         int i = original.call(instance, recipeHolder, intList);
         return GcaSetting.betterQuickCrafting ? i - 1 : i;
     }
-    //#else
-    //$$ @WrapOperation(method = "handleRecipeClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/StackedContents;getBiggestCraftableStack(Lnet/minecraft/world/item/crafting/Recipe;Lit/unimi/dsi/fastutil/ints/IntList;)I"))
-    //$$ private int handleRecipeClicked(StackedContents instance, Recipe<?> recipe, IntList intList, Operation<Integer> original) {
-    //$$     int i = original.call(instance, recipe, intList);
-    //$$     return GcaSetting.betterQuickCrafting ? i - 1 : i;
-    //$$ }
-    //#endif
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/GameProfileHelper.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/GameProfileHelper.java
@@ -9,129 +9,38 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
 import org.jetbrains.annotations.NotNull;
 import com.mojang.authlib.GameProfile;
-//#if MC>=12109
-//$$ import net.minecraft.world.item.component.ResolvableProfile;
-//$$ import net.minecraft.server.players.NameAndId;
-//$$ import java.util.concurrent.CompletableFuture;
-//#endif
 
 import java.util.UUID;
 
-
 public class GameProfileHelper {
     public static String prasePlayerGameName(@NotNull ServerPlayer player) {
-        //#if MC<12109
         return player.getGameProfile().getName();
-        //#else
-        //$$ return player.nameAndId().name();
-        //#endif
     }
 
     public static UUID prasePlayerGameID(@NotNull ServerPlayer player) {
-        //#if MC<12109
         return player.getGameProfile().getId();
-        //#else
-        //$$ return player.nameAndId().id();
-        //#endif
     }
 
-    public static @NotNull
-    //#if MC<12109
-    GameProfile
-    //#else
-    //$$ NameAndId
-    //#endif
-    prasePlayerGameProfile(@NotNull ServerPlayer player) {
-        //#if MC<12109
+    public static @NotNull GameProfile prasePlayerGameProfile(@NotNull ServerPlayer player) {
         return player.getGameProfile();
-        //#else
-        //$$ return player.nameAndId();
-        //#endif
     }
 
-    public static void prasePlayerGameProfile(
-        @NotNull ServerPlayer player,
-        @NotNull TriConsumer<
-            //#if MC<12109
-            GameProfile,
-            //#else
-            //$$ NameAndId,
-            //#endif
-            String,
-            UUID
-            > consumer
-    ) {
-        //#if MC<12109
+    public static void prasePlayerGameProfile(@NotNull ServerPlayer player, @NotNull TriConsumer<GameProfile, String, UUID> consumer) {
         GameProfile profile = player.getGameProfile();
-        //#else
-        //$$ NameAndId profile = player.nameAndId();
-        //#endif
-        consumer.accept(
-            profile,
-            //#if MC<12109
-            profile.getName(),
-            profile.getId()
-            //#else
-            //$$ profile.name(),
-            //$$ profile.id()
-            //#endif
-        );
+        consumer.accept(profile, profile.getName(), profile.getId());
     }
 
-    public static void praseGameProfileCollection(
-        CommandContext<CommandSourceStack> context,
-        String name,
-        TriConsumer<
-            //#if MC<12109
-            GameProfile,
-            //#else
-            //$$ NameAndId,
-            //#endif
-            String,
-            UUID
-            > consumer
-    ) throws CommandSyntaxException {
-        for (
-            //#if MC<12109
-            GameProfile profile
-            //#else
-            //$$ NameAndId profile
-            //#endif
-            : GameProfileArgument.getGameProfiles(context, name)
-        ) {
-            consumer.accept(
-                profile,
-                //#if MC<12109
-                profile.getName(),
-                profile.getId()
-                //#else
-                //$$ profile.name(),
-                //$$ profile.id()
-                //#endif
-            );
+    public static void praseGameProfileCollection(CommandContext<CommandSourceStack> context, String name, TriConsumer<GameProfile, String, UUID> consumer) throws CommandSyntaxException {
+        for (GameProfile profile : GameProfileArgument.getGameProfiles(context, name)) {
+            consumer.accept(profile, profile.getName(), profile.getId());
         }
     }
 
     public static MinecraftServer getServerPlayerServer(@NotNull ServerPlayer player) {
-        //#if MC<12109
         return player.getServer();
-        //#else
-        //$$ return player.level().getServer();
-        //#endif
     }
 
     public static GameProfileCache getProfileCache(@NotNull MinecraftServer server) {
-        //#if MC<12109
         return server.getProfileCache();
-        //#else
-        //$$ return (CachedUserNameToIdResolver) server.services().nameToIdCache();
-        //#endif
     }
-
-    //#if MC>=12109
-    //$$ public static CompletableFuture<GameProfile> fetchGameProfile(@NotNull MinecraftServer server, UUID name) {
-    //$$     ResolvableProfile resolvableProfile = ResolvableProfile.createUnresolved(name);
-    //$$     return resolvableProfile.resolveProfile(server.services().profileResolver());
-    //$$ }
-    //#endif
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerResident.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerResident.java
@@ -41,10 +41,6 @@ import net.minecraft.world.level.block.entity.SkullBlockEntity;
 //#else
 //#endif
 
-//#if MC>=12109
-//$$ import net.minecraft.server.players.NameAndId;
-//#endif
-
 public class FakePlayerResident {
     public static @NotNull JsonObject save(Player player) {
         JsonObject fakePlayer = new JsonObject();
@@ -52,17 +48,6 @@ public class FakePlayerResident {
             EntityPlayerActionPack actionPack = ((ServerPlayerInterface) player).getActionPack();
             fakePlayer.add("actions", FakePlayerSerializer.actionPackToJson(actionPack));
         }
-        //#if MC>=12109
-        //$$ JsonArray pos = new JsonArray();
-        //$$ Vec3 position = player.position();
-        //$$ Vec2 rotation = player.getRotationVector();
-        //$$ pos.add(position.x);
-        //$$ pos.add(position.y);
-        //$$ pos.add(position.z);
-        //$$ pos.add(rotation.x);
-        //$$ pos.add(rotation.y);
-        //$$ fakePlayer.add("pos", pos);
-        //#endif
         return fakePlayer;
     }
 
@@ -73,85 +58,58 @@ public class FakePlayerResident {
         Vec3 position,
         Vec2 rotation
     ) {
-        //#if MC<12109
         GameProfileCache.setUsesAuthentication(false);
         GameProfile gameprofile;
-        //#else
-        //$$ NameAndId gameprofile;
-        //#endif
         try {
             GameProfileCache profileCache = GameProfileHelper.getProfileCache(server);
             if (profileCache == null) {
                 return;
             }
-            //#if MC<12109
             gameprofile = profileCache.get(username).orElse(null);
-            //#else
-            //$$ profileCache.resolveOfflineUsers(true);
-            //$$ gameprofile = profileCache.get(username).orElse(null);
-            //$$ profileCache.resolveOfflineUsers(server.isDedicatedServer() && server.usesAuthentication());
-            //#endif
         } finally {
-            //#if MC<12109
             GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());
-            //#endif
         }
         if (gameprofile == null) {
             if (!CarpetSettings.allowSpawningOfflinePlayers) {
                 GcaExtension.LOGGER.error("Spawning offline players {} is not allowed!", username);
                 return;
             }
-            //#if MC<12109
             gameprofile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(username), username);
-            //#else
-            //$$ gameprofile = new NameAndId(UUIDUtil.createOfflinePlayerUUID(username), username);
-            //#endif
         }
         //#if MC>=12100
-        //#if MC<12109
         GameProfile finalGameprofile = gameprofile;
-        //#endif
-        //#if MC<12109
-        SkullBlockEntity.fetchGameProfile(gameprofile.getName())
-        //#else
-        //$$ GameProfileHelper.fetchGameProfile(server, gameprofile.id())
-        //#endif
-            .thenAcceptAsync((p) -> {
-                //#if MC<12109
-                GameProfile current = finalGameprofile;
-                if (p.isPresent()) {
-                    current = p.get();
-                }
-                //#else
-                //$$ GameProfile current = p;
-                //#endif
-                EntityPlayerMPFake playerMPFake = EntityPlayerMPFake.respawnFake(server, server.overworld(), current, ClientInformation.createDefault());
-                server.getPlayerList().placeNewPlayer(
-                    new FakeClientConnection(PacketFlow.SERVERBOUND),
-                    playerMPFake,
-                    new CommonListenerCookie(current, 0, playerMPFake.clientInformation(), false)
-                );
-                if (position != null) {
-                    playerMPFake.moveTo(position);
-                }
-                if (rotation != null) {
-                    playerMPFake.setXRot(rotation.x);
-                    playerMPFake.setYRot(rotation.y);
-                }
-                playerMPFake.setHealth(20.0F);
-                AttributeInstance attribute = playerMPFake.getAttribute(Attributes.STEP_HEIGHT);
-                if (attribute != null) attribute.setBaseValue(0.6F);
-                server.getPlayerList().broadcastAll(new ClientboundRotateHeadPacket(playerMPFake, ((byte) (playerMPFake.yHeadRot * 256.0F / 360.0F))), playerMPFake.level().dimension());
-                //#if MC>=12102
-                //$$ server.getPlayerList().broadcastAll(ClientboundEntityPositionSyncPacket.of(playerMPFake), playerMPFake.level().dimension());
-                //#else
-                server.getPlayerList().broadcastAll(new ClientboundTeleportEntityPacket(playerMPFake), playerMPFake.level().dimension());
-                //#endif
-                playerMPFake.getEntityData().set(PlayerAccessor.getCustomisationData(), (byte) 127);
+        SkullBlockEntity.fetchGameProfile(gameprofile.getName()).thenAcceptAsync((p) -> {
+            GameProfile current = finalGameprofile;
+            if (p.isPresent()) {
+                current = p.get();
+            }
+            EntityPlayerMPFake playerMPFake = EntityPlayerMPFake.respawnFake(server, server.overworld(), current, ClientInformation.createDefault());
+            server.getPlayerList().placeNewPlayer(
+                new FakeClientConnection(PacketFlow.SERVERBOUND),
+                playerMPFake,
+                new CommonListenerCookie(current, 0, playerMPFake.clientInformation(), false)
+            );
+            if (position != null) {
+                playerMPFake.moveTo(position);
+            }
+            if (rotation != null) {
+                playerMPFake.setXRot(rotation.x);
+                playerMPFake.setYRot(rotation.y);
+            }
+            playerMPFake.setHealth(20.0F);
+            AttributeInstance attribute = playerMPFake.getAttribute(Attributes.STEP_HEIGHT);
+            if (attribute != null) attribute.setBaseValue(0.6F);
+            server.getPlayerList().broadcastAll(new ClientboundRotateHeadPacket(playerMPFake, ((byte) (playerMPFake.yHeadRot * 256.0F / 360.0F))), playerMPFake.level().dimension());
+            //#if MC>=12102
+            //$$ server.getPlayerList().broadcastAll(ClientboundEntityPositionSyncPacket.of(playerMPFake), playerMPFake.level().dimension());
+            //#else
+            server.getPlayerList().broadcastAll(new ClientboundTeleportEntityPacket(playerMPFake), playerMPFake.level().dimension());
+            //#endif
+            playerMPFake.getEntityData().set(PlayerAccessor.getCustomisationData(), (byte) 127);
 
-                FakePlayerSerializer.applyActionPackFromJson(actions, playerMPFake);
-                ((EntityInvoker) playerMPFake).invokerUnsetRemoved();
-            }, server);
+            FakePlayerSerializer.applyActionPackFromJson(actions, playerMPFake);
+            ((EntityInvoker) playerMPFake).invokerUnsetRemoved();
+        }, server);
         //#else
         //$$ EntityPlayerMPFake playerMPFake = EntityPlayerMPFake.respawnFake(server, server.overworld(), gameprofile);
         //$$ server.getPlayerList().placeNewPlayer(new FakeClientConnection(PacketFlow.SERVERBOUND), playerMPFake);

--- a/versions/1.20.1/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
+++ b/versions/1.20.1/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
@@ -1,0 +1,22 @@
+package dev.dubhe.gugle.carpet.mixin;
+
+import dev.dubhe.gugle.carpet.GcaSetting;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import net.minecraft.world.item.crafting.Recipe;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.world.entity.player.StackedContents;
+
+@Mixin(ServerPlaceRecipe.class)
+abstract class ServerPlaceRecipeMixin {
+    @WrapOperation(method = "handleRecipeClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/StackedContents;getBiggestCraftableStack(Lnet/minecraft/world/item/crafting/Recipe;Lit/unimi/dsi/fastutil/ints/IntList;)I"))
+    private int handleRecipeClicked(StackedContents instance, Recipe<?> recipe, IntList intList, Operation<Integer> original) {
+        int i = original.call(instance, recipe, intList);
+        return GcaSetting.betterQuickCrafting ? i - 1 : i;
+    }
+}

--- a/versions/1.21.10/src/main/java/dev/dubhe/gugle/carpet/tools/GameProfileHelper.java
+++ b/versions/1.21.10/src/main/java/dev/dubhe/gugle/carpet/tools/GameProfileHelper.java
@@ -1,0 +1,59 @@
+package dev.dubhe.gugle.carpet.tools;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.CachedUserNameToIdResolver;
+import org.jetbrains.annotations.NotNull;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.world.item.component.ResolvableProfile;
+import net.minecraft.server.players.NameAndId;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.UUID;
+
+public class GameProfileHelper {
+    public static String prasePlayerGameName(@NotNull ServerPlayer player) {
+        return player.nameAndId().name();
+    }
+
+    public static UUID prasePlayerGameID(@NotNull ServerPlayer player) {
+        return player.nameAndId().id();
+    }
+
+    public static @NotNull NameAndId prasePlayerGameProfile(@NotNull ServerPlayer player) {
+        return player.nameAndId();
+    }
+
+    public static void prasePlayerGameProfile(@NotNull ServerPlayer player, @NotNull TriConsumer<NameAndId, String, UUID> consumer) {
+        NameAndId profile = player.nameAndId();
+        consumer.accept(profile, profile.name(), profile.id());
+    }
+
+    public static void praseGameProfileCollection(CommandContext<CommandSourceStack> context, String name, TriConsumer<NameAndId, String, UUID> consumer) throws CommandSyntaxException {
+        for (NameAndId profile : GameProfileArgument.getGameProfiles(context, name)) {
+            consumer.accept(profile, profile.name(), profile.id());
+        }
+    }
+
+    public static MinecraftServer getServerPlayerServer(@NotNull ServerPlayer player) {
+        return player.level().getServer();
+    }
+
+    public static CachedUserNameToIdResolver getProfileCache(@NotNull MinecraftServer server) {
+        return (CachedUserNameToIdResolver) server.services().nameToIdCache();
+    }
+
+    public static CompletableFuture<GameProfile> fetchGameProfile(@NotNull MinecraftServer server, UUID name) {
+        ResolvableProfile resolvableProfile = ResolvableProfile.createUnresolved(name);
+        return resolvableProfile.resolveProfile(server.services().profileResolver());
+    }
+
+    public static CompletableFuture<GameProfile> fetchGameProfile(@NotNull MinecraftServer server, String name) {
+        ResolvableProfile resolvableProfile = ResolvableProfile.createUnresolved(name);
+        return resolvableProfile.resolveProfile(server.services().profileResolver());
+    }
+}

--- a/versions/1.21.10/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerResident.java
+++ b/versions/1.21.10/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerResident.java
@@ -1,0 +1,110 @@
+package dev.dubhe.gugle.carpet.tools.player;
+
+import carpet.fakes.ServerPlayerInterface;
+import carpet.helpers.EntityPlayerActionPack;
+import carpet.patches.EntityPlayerMPFake;
+import carpet.patches.FakeClientConnection;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.dubhe.gugle.carpet.GcaExtension;
+import dev.dubhe.gugle.carpet.GcaSetting;
+import dev.dubhe.gugle.carpet.mixin.EntityInvoker;
+import dev.dubhe.gugle.carpet.mixin.PlayerAccessor;
+import dev.dubhe.gugle.carpet.tools.GameProfileHelper;
+import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.network.protocol.game.ClientboundRotateHeadPacket;
+import net.minecraft.network.protocol.game.ClientboundEntityPositionSyncPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec2;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+
+import net.minecraft.server.level.ClientInformation;
+import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+
+public class FakePlayerResident {
+    public static @NotNull JsonObject save(Player player) {
+        JsonObject fakePlayer = new JsonObject();
+        if (GcaSetting.fakePlayerReloadAction) {
+            EntityPlayerActionPack actionPack = ((ServerPlayerInterface) player).getActionPack();
+            fakePlayer.add("actions", FakePlayerSerializer.actionPackToJson(actionPack));
+        }
+        JsonArray pos = new JsonArray();
+        Vec3 position = player.position();
+        Vec2 rotation = player.getRotationVector();
+        pos.add(position.x);
+        pos.add(position.y);
+        pos.add(position.z);
+        pos.add(rotation.x);
+        pos.add(rotation.y);
+        fakePlayer.add("pos", pos);
+        return fakePlayer;
+    }
+
+    public static void createFake(
+        String username,
+        @NotNull MinecraftServer server,
+        final JsonObject actions,
+        Vec3 position,
+        Vec2 rotation
+    ) {
+        GameProfileHelper.fetchGameProfile(server, username)
+            .thenAcceptAsync((profile) -> {
+                EntityPlayerMPFake playerMPFake = EntityPlayerMPFake.respawnFake(server, server.overworld(), profile, ClientInformation.createDefault());
+                server.getPlayerList().placeNewPlayer(
+                    new FakeClientConnection(PacketFlow.SERVERBOUND),
+                    playerMPFake,
+                    new CommonListenerCookie(profile, 0, playerMPFake.clientInformation(), false)
+                );
+                if (position != null) {
+                    playerMPFake.snapTo(position);
+                }
+                if (rotation != null) {
+                    playerMPFake.setXRot(rotation.x);
+                    playerMPFake.setYRot(rotation.y);
+                }
+                playerMPFake.setHealth(20.0F);
+                AttributeInstance attribute = playerMPFake.getAttribute(Attributes.STEP_HEIGHT);
+                if (attribute != null) attribute.setBaseValue(0.6F);
+                server.getPlayerList().broadcastAll(new ClientboundRotateHeadPacket(playerMPFake, ((byte) (playerMPFake.yHeadRot * 256.0F / 360.0F))), playerMPFake.level().dimension());
+                server.getPlayerList().broadcastAll(ClientboundEntityPositionSyncPacket.of(playerMPFake), playerMPFake.level().dimension());
+                playerMPFake.getEntityData().set(PlayerAccessor.getCustomisationData(), (byte) 127);
+
+                FakePlayerSerializer.applyActionPackFromJson(actions, playerMPFake);
+                ((EntityInvoker) playerMPFake).invokerUnsetRemoved();
+            }, server);
+    }
+
+    public static void load(Map.@NotNull Entry<String, JsonElement> entry, MinecraftServer server) {
+        String username = entry.getKey();
+        JsonObject fakePlayer = entry.getValue().getAsJsonObject();
+        JsonObject actions = new JsonObject();
+        if (GcaSetting.fakePlayerReloadAction && fakePlayer.has("actions")) {
+            actions = fakePlayer.get("actions").getAsJsonObject();
+        }
+        Vec3 position = null;
+        Vec2 rotation = null;
+        if (fakePlayer.has("pos")) {
+            JsonArray pos = fakePlayer.get("pos").getAsJsonArray();
+            position = new Vec3(pos.get(0).getAsDouble(), pos.get(1).getAsDouble(), pos.get(2).getAsDouble());
+            if (pos.size() > 3) {
+                rotation = new Vec2(pos.get(3).getAsFloat(), pos.get(4).getAsFloat());
+            }
+        }
+        GcaExtension.LOGGER.info(
+            "Load fake player {} at [{}, {}, {}]",
+            username,
+            position == null ? "null" : position.x,
+            position == null ? "null" : position.y,
+            position == null ? "null" : position.z
+        );
+        FakePlayerResident.createFake(username, server, actions, position, rotation);
+    }
+}

--- a/versions/1.21.2/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
+++ b/versions/1.21.2/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlaceRecipeMixin.java
@@ -1,0 +1,35 @@
+package dev.dubhe.gugle.carpet.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import dev.dubhe.gugle.carpet.GcaSetting;
+
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlaceRecipe.class)
+abstract class ServerPlaceRecipeMixin {
+
+    @Shadow
+    @Final
+    private boolean useMaxItems;
+
+    @WrapOperation(method = "placeRecipe(Lnet/minecraft/world/item/crafting/RecipeHolder;Lnet/minecraft/world/entity/player/StackedItemContents;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/recipebook/ServerPlaceRecipe;calculateAmountToCraft(IZ)I"))
+    private int calculateAmountToCraft(ServerPlaceRecipe<?> instance, int i, boolean bl, Operation<Integer> original, @Cancellable CallbackInfo cir) {
+        if (GcaSetting.betterQuickCrafting && this.useMaxItems) {
+            if (i <= 1) {
+                cir.cancel();
+                return 0;
+            }
+            i--;
+        }
+        return original.call(instance, i, bl);
+    }
+
+}


### PR DESCRIPTION
- 使用更优的preprocess处理方式
- 修改项目依赖关系, 使所有版本均依赖上一个版本, 而不是1.21.1
- 修复假人驻留重进游戏后没有名称的问题
- 优化 betterQuickCrafting 逻辑, 减少注入
