### PR TITLE
修复正版模式下假人相关的一些问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,16 @@ jobs:
       - name: Build
         run: ./gradlew build
 
-      - run: ./gradlew build publishMods
+      - name: Publish
+        if: ${{ !contains(github.event.head_commit.message, '- pass publish') }}
+        run: ./gradlew build publishMods
         env:
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            */**/build/libs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 
 mod_id=gca
 mod_name=GugleCarpetAddition
-mod_version=2.11.1
+mod_version=2.11.2
 maven_group=dev.dubhe.gugle
 archives_base_name=gugle-carpet-addition
 

--- a/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -243,12 +244,12 @@ public class BotCommand {
         GroupNode group = getGroupNode(context, groupName);
         if (group == null) return 0;
         CommandSourceStack source = context.getSource();
-        List<String> bots = group.group.bots();
+        List<String> bots = new ArrayList<>(group.group.bots());
         if (!bots.remove(botName)) {
             source.sendFailure(Component.literal("Bot %s is not found in the %s.".formatted(botName, groupName)));
             return 0;
         }
-        BOT_GROUP_CONFIG.update(group.group);
+        BOT_GROUP_CONFIG.update(new BotGroupInfo(groupName, bots));
         source.sendSuccess(() -> Component.literal("Bot %s is removed from %s successfully.".formatted(botName, groupName)), false);
         return Command.SINGLE_SUCCESS;
     }
@@ -259,13 +260,13 @@ public class BotCommand {
         GroupNode group = getGroupNode(context, groupName);
         if (group == null) return 0;
         CommandSourceStack source = context.getSource();
-        List<String> bots = group.group.bots();
+        List<String> bots = new ArrayList<>(group.group.bots());
         if (bots.contains(botName)) {
             source.sendFailure(Component.literal("Bot %s is already added.".formatted(botName)));
             return 0;
         }
         bots.add(botName);
-        BOT_GROUP_CONFIG.update(group.group);
+        BOT_GROUP_CONFIG.update(new BotGroupInfo(groupName, bots));
         source.sendSuccess(() -> Component.literal("Bot %s is added to %s successfully.".formatted(botName, groupName)), false);
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -197,9 +197,13 @@ public class ConfigUpdater {
                 Codec<Map<String, T>> fileCodec = Codec.unboundedMap(Codec.STRING, codec);
                 if (fileMapper.newName.toFile().exists()) {
                     String already = Files.readString(fileMapper.newName, StandardCharsets.UTF_8);
-                    fileCodec.parse(JsonOps.INSTANCE, JsonParser.parseString(already))
-                        .result()
-                        .ifPresent(contents::putAll);
+                    DataResult<Map<String, T>> parseResult = fileCodec.parse(JsonOps.INSTANCE, JsonParser.parseString(already));
+                    if (parseResult.error().isPresent()) {
+                        LOGGER.warn("Failed to parse existing config file: {}, this file will be overwritten.", fileMapper.newName);
+                        LOGGER.warn("{}", parseResult.error().get().message());
+                    } else {
+                        parseResult.result().ifPresent(contents::putAll);
+                    }
                 }
 
                 for (T data : list) {

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -137,7 +138,11 @@ public class ConfigUpdater {
             String name = entry.getKey();
             JsonObject value = entry.getValue().getAsJsonObject();
             UUID uuid = getUUIDByName(services, name);
-            File file = new File(playerDir, uuid.toString() + ".dat");
+            if (uuid == null) {
+                GcaExtension.LOGGER.info("Failed to get UUID for {}, skipping...", name);
+                return null;
+            }
+            File file = new File(playerDir, uuid + ".dat");
             if (!file.exists() || !file.isFile()) {
                 GcaExtension.LOGGER.warn("Player data file not found for {}, skipping...", name);
                 return null;
@@ -192,6 +197,7 @@ public class ConfigUpdater {
         }
     }
 
+    @Nullable
     private static UUID getUUIDByName(Services services, String name) {
         return services
             //#if MC < 12109

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -4,8 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
-import com.mojang.authlib.GameProfile;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
@@ -23,6 +23,7 @@ import dev.dubhe.gugle.carpet.config.updater.serializer.ResourceLocationSerializ
 import dev.dubhe.gugle.carpet.config.updater.serializer.ChatFormattingSerializer;
 import dev.dubhe.gugle.carpet.config.updater.serializer.DimTypeSerializer;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtOps;
@@ -41,6 +42,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,7 +59,14 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.util.Mth;
 //#endif
+//#if MC < 12109
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.players.GameProfileCache;
 
+//#else
+//$$ import net.minecraft.server.players.NameAndId;
+//$$ import net.minecraft.util.StringUtil;
+//#endif
 public class ConfigUpdater {
     public static final Gson GSON = new GsonBuilder()
         .setPrettyPrinting()
@@ -66,7 +75,7 @@ public class ConfigUpdater {
         .registerTypeHierarchyAdapter(ChatFormatting.class, new ChatFormattingSerializer())
         .create();
 
-    public static void tryUpdateOldVersion(LevelStorageSource.LevelStorageAccess access, Services services) {
+    public static void tryUpdateOldVersion(LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
         Path levelPath = access.getLevelPath(LevelResource.ROOT);
         GcaExtension.LOGGER.info("Checking old config files...");
 
@@ -95,7 +104,7 @@ public class ConfigUpdater {
 
         updateWelcome(NameMapper.of(levelPath, "welcome"));
 
-        updateResident(NameMapper.of(levelPath, "fake_player", "residents"), access, services);
+        updateResident(NameMapper.of(levelPath, "fake_player", "residents"), access, services, onelineMode);
     }
 
     private static <T, R extends IWithName> void updateMapping(NameMapper fileMapper, Class<T> tClass, Codec<R> codec, Function<T, R> function) {
@@ -132,14 +141,14 @@ public class ConfigUpdater {
         });
     }
 
-    private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services) {
+    private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
         File playerDir = access.getLevelPath(LevelResource.PLAYER_DATA_DIR).toFile();
         updateNormalResolver(fileMapper, BotInfo.CODEC, entry -> {
             String name = entry.getKey();
             JsonObject value = entry.getValue().getAsJsonObject();
-            UUID uuid = getUUIDByName(services, name);
+            UUID uuid = getUUIDByName(services, name, onelineMode);
             if (uuid == null) {
-                GcaExtension.LOGGER.info("Failed to get UUID for {}, skipping...", name);
+                GcaExtension.LOGGER.warn("Failed to get UUID for {}, skipping...", name);
                 return null;
             }
             File file = new File(playerDir, uuid + ".dat");
@@ -176,10 +185,23 @@ public class ConfigUpdater {
             List<T> list = function.apply(json);
 
             if (!list.isEmpty()) {
-                Map<String, T> contents = list.stream().collect(Collectors.toMap(IWithName::name, it -> it, (a, b) -> b));
+                Map<String, T> contents = new LinkedHashMap<>();
 
-                Codec<Map<String, T>> resultCodec = Codec.unboundedMap(Codec.STRING, codec);
-                DataResult<JsonElement> result = resultCodec.encodeStart(JsonOps.INSTANCE, contents);
+                Codec<Map<String, T>> fileCodec = Codec.unboundedMap(Codec.STRING, codec);
+                if (fileMapper.newName.toFile().exists()) {
+                    String already = Files.readString(fileMapper.newName, StandardCharsets.UTF_8);
+                    fileCodec.parse(JsonOps.INSTANCE, JsonParser.parseString(already))
+                        .result()
+                        .ifPresent(contents::putAll);
+                }
+
+                for (T data : list) {
+                    String name = data.name();
+                    if (contents.containsKey(name)) continue;
+                    contents.put(name, data);
+                }
+
+                DataResult<JsonElement> result = fileCodec.encodeStart(JsonOps.INSTANCE, contents);
 
                 if (result.error().isPresent()) {
                     GcaExtension.LOGGER.error("Failed to encode config: {}", result.error().get().message());
@@ -198,14 +220,31 @@ public class ConfigUpdater {
     }
 
     @Nullable
-    private static UUID getUUIDByName(Services services, String name) {
-        return services
-            //#if MC < 12109
-            .profileCache().get(name)
-            //#else
-            //$$ .profileResolver().fetchByName(name)
-            //#endif
-            .map(GameProfile::getId).orElse(null);
+    private static UUID getUUIDByName(Services services, String name, boolean onelineMode) {
+        //#if MC < 12109
+        GameProfileCache.setUsesAuthentication(false);
+        GameProfile gameprofile;
+        try {
+            gameprofile = services.profileCache().get(name).orElse(null);
+        } finally {
+            GameProfileCache.setUsesAuthentication(onelineMode);
+        }
+        if (gameprofile == null) {
+            gameprofile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(name), name);
+        }
+        return gameprofile.getId();
+        //#else
+        //$$ services.nameToIdCache().resolveOfflineUsers(false);
+        //$$ if (!StringUtil.isNullOrEmpty(name) && name.length() <= 16) {
+        //$$     Optional<UUID> optional = services.nameToIdCache().get(name).map(NameAndId::id);
+        //$$     return optional.orElseGet(() -> UUIDUtil.createOfflinePlayerUUID(name));
+        //$$ }
+        //$$ try {
+        //$$     return UUID.fromString(name);
+        //$$ } catch (IllegalArgumentException var5) {
+        //$$     return null;
+        //$$ }
+        //#endif
     }
 
     private static Optional<CompoundTag> getPlayerData(File file) {

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -62,12 +62,15 @@ import net.minecraft.util.Mth;
 //#if MC < 12109
 import com.mojang.authlib.GameProfile;
 import net.minecraft.server.players.GameProfileCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 //#else
 //$$ import net.minecraft.server.players.NameAndId;
 //$$ import net.minecraft.util.StringUtil;
 //#endif
 public class ConfigUpdater {
+    public static final Logger LOGGER = LoggerFactory.getLogger("GcaConfigUpdater");
     public static final Gson GSON = new GsonBuilder()
         .setPrettyPrinting()
         .registerTypeHierarchyAdapter(ResourceKey.class, new DimTypeSerializer())
@@ -77,7 +80,7 @@ public class ConfigUpdater {
 
     public static void tryUpdateOldVersion(LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
         Path levelPath = access.getLevelPath(LevelResource.ROOT);
-        GcaExtension.LOGGER.info("Checking old config files...");
+        LOGGER.info("Checking old config files...");
 
         updateMapping(NameMapper.of(levelPath, "bot"), DeprecatedBotInfo.class, BotInfo.CODEC, info -> {
             BotActionInfo actions = BotActionInfo.CODEC.parse(JsonOps.INSTANCE, info.actions).result().orElse(BotActionInfo.EMPTY);
@@ -143,9 +146,9 @@ public class ConfigUpdater {
 
     private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
         try {
-            Files.deleteIfExists(access.getLevelPath(LevelResource.ROOT).resolve("fake_player.old.gca.json"));
+            Files.deleteIfExists(access.getLevelPath(LevelResource.ROOT).resolve("fake_player.gca.old.json"));
         } catch (Exception e) {
-            GcaExtension.LOGGER.warn("Failed to delete old fake_player config backup file.", e);
+            LOGGER.warn("Failed to delete old fake_player config backup file.", e);
         }
         File playerDir = access.getLevelPath(LevelResource.PLAYER_DATA_DIR).toFile();
         updateNormalResolver(fileMapper, BotInfo.CODEC, entry -> {
@@ -153,17 +156,17 @@ public class ConfigUpdater {
             JsonObject value = entry.getValue().getAsJsonObject();
             UUID uuid = getUUIDByName(services, name, onelineMode);
             if (uuid == null) {
-                GcaExtension.LOGGER.warn("Failed to get UUID for {}, skipping...", name);
+                LOGGER.warn("Failed to get UUID for {}, skipping...", name);
                 return null;
             }
             File file = new File(playerDir, uuid + ".dat");
             if (!file.exists() || !file.isFile()) {
-                GcaExtension.LOGGER.warn("Player data file not found for {}, skipping...", name);
+                LOGGER.warn("Player data file not found for {}, skipping...", name);
                 return null;
             }
             Optional<CompoundTag> optional = getPlayerData(file);
             if (optional.isEmpty()) {
-                GcaExtension.LOGGER.warn("Failed to load player data for {}, skipping...", name);
+                LOGGER.warn("Failed to load player data for {}, skipping...", name);
                 return null;
             }
             BotActionInfo actions = BotActionInfo.CODEC.parse(JsonOps.INSTANCE, value.get("actions")).result().orElse(BotActionInfo.EMPTY);
@@ -182,7 +185,7 @@ public class ConfigUpdater {
 
     private static <T extends IWithName> void updateResolver(NameMapper fileMapper, Codec<T> codec, Function<JsonObject, List<T>> function) {
         if (!fileMapper.oldPath.toFile().exists()) return;
-        GcaExtension.LOGGER.info("Found old config file: {}, trying to update...", fileMapper.oldPath);
+        LOGGER.info("Found old config file: {}, trying to update...", fileMapper.oldPath);
         try {
             String jsonStr = Files.readString(fileMapper.oldPath);
             JsonObject json = GSON.fromJson(jsonStr, JsonObject.class);
@@ -209,7 +212,7 @@ public class ConfigUpdater {
                 DataResult<JsonElement> result = fileCodec.encodeStart(JsonOps.INSTANCE, contents);
 
                 if (result.error().isPresent()) {
-                    GcaExtension.LOGGER.error("Failed to encode config: {}", result.error().get().message());
+                    LOGGER.error("Failed to encode config: {}", result.error().get().message());
                     return;
                 }
 
@@ -220,7 +223,7 @@ public class ConfigUpdater {
 
             Files.deleteIfExists(fileMapper.oldPath);
         } catch (Exception e) {
-            GcaExtension.LOGGER.warn("Failed to update old config: {}", fileMapper.oldPath, e);
+            LOGGER.warn("Failed to update old config: {}", fileMapper.oldPath, e);
         }
     }
 
@@ -287,7 +290,7 @@ public class ConfigUpdater {
 //$$             .orElse(false);
         //#endif
         ResourceKey<Level> dimension = Level.RESOURCE_KEY_CODEC.parse(NbtOps.INSTANCE, playerData.get("Dimension"))
-            .resultOrPartial(GcaExtension.LOGGER::error)
+            .resultOrPartial(LOGGER::error)
             .orElse(Level.OVERWORLD);
         return new BotInfo(name, "Resident bot imported from old config", pos, facing, dimension, mode, flying, actions);
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -37,6 +37,8 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -62,9 +64,6 @@ import net.minecraft.util.Mth;
 //#if MC < 12109
 import com.mojang.authlib.GameProfile;
 import net.minecraft.server.players.GameProfileCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 //#else
 //$$ import net.minecraft.server.players.NameAndId;
 //$$ import net.minecraft.util.StringUtil;

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -142,6 +142,11 @@ public class ConfigUpdater {
     }
 
     private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
+        try {
+            Files.deleteIfExists(access.getLevelPath(LevelResource.ROOT).resolve("fake_player.old.gca.json"));
+        } catch (Exception e) {
+            GcaExtension.LOGGER.warn("Failed to delete old fake_player config backup file.", e);
+        }
         File playerDir = access.getLevelPath(LevelResource.PLAYER_DATA_DIR).toFile();
         updateNormalResolver(fileMapper, BotInfo.CODEC, entry -> {
             String name = entry.getKey();

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/ConfigUpdater.java
@@ -77,7 +77,7 @@ public class ConfigUpdater {
         .registerTypeHierarchyAdapter(ChatFormatting.class, new ChatFormattingSerializer())
         .create();
 
-    public static void tryUpdateOldVersion(LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
+    public static void tryUpdateOldVersion(LevelStorageSource.LevelStorageAccess access, Services services, boolean onlineMode) {
         Path levelPath = access.getLevelPath(LevelResource.ROOT);
         LOGGER.info("Checking old config files...");
 
@@ -106,7 +106,7 @@ public class ConfigUpdater {
 
         updateWelcome(NameMapper.of(levelPath, "welcome"));
 
-        updateResident(NameMapper.of(levelPath, "fake_player", "residents"), access, services, onelineMode);
+        updateResident(NameMapper.of(levelPath, "fake_player", "residents"), access, services, onlineMode);
     }
 
     private static <T, R extends IWithName> void updateMapping(NameMapper fileMapper, Class<T> tClass, Codec<R> codec, Function<T, R> function) {
@@ -143,7 +143,7 @@ public class ConfigUpdater {
         });
     }
 
-    private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services, boolean onelineMode) {
+    private static void updateResident(NameMapper fileMapper, LevelStorageSource.LevelStorageAccess access, Services services, boolean onlineMode) {
         try {
             Files.deleteIfExists(access.getLevelPath(LevelResource.ROOT).resolve("fake_player.gca.old.json"));
         } catch (Exception e) {
@@ -153,7 +153,7 @@ public class ConfigUpdater {
         updateNormalResolver(fileMapper, BotInfo.CODEC, entry -> {
             String name = entry.getKey();
             JsonObject value = entry.getValue().getAsJsonObject();
-            UUID uuid = getUUIDByName(services, name, onelineMode);
+            UUID uuid = getUUIDByName(services, name, onlineMode);
             if (uuid == null) {
                 LOGGER.warn("Failed to get UUID for {}, skipping...", name);
                 return null;
@@ -227,14 +227,14 @@ public class ConfigUpdater {
     }
 
     @Nullable
-    private static UUID getUUIDByName(Services services, String name, boolean onelineMode) {
+    private static UUID getUUIDByName(Services services, String name, boolean onlineMode) {
         //#if MC < 12109
         GameProfileCache.setUsesAuthentication(false);
         GameProfile gameprofile;
         try {
             gameprofile = services.profileCache().get(name).orElse(null);
         } finally {
-            GameProfileCache.setUsesAuthentication(onelineMode);
+            GameProfileCache.setUsesAuthentication(onlineMode);
         }
         if (gameprofile == null) {
             gameprofile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(name), name);

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/MainServerMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/MainServerMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import dev.dubhe.gugle.carpet.config.updater.ConfigUpdater;
 import net.minecraft.server.Main;
 import net.minecraft.server.Services;
+import net.minecraft.server.dedicated.DedicatedServerSettings;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Main.class)
 public class MainServerMixin {
     @Inject(method = "main", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;spin(Ljava/util/function/Function;)Lnet/minecraft/server/MinecraftServer;"))
-    private static void updateConfig(String[] strings, CallbackInfo ci, @Local Services services, @Local LevelStorageSource.LevelStorageAccess levelStorageAccess) {
-        ConfigUpdater.tryUpdateOldVersion(levelStorageAccess, services);
+    private static void updateConfig(String[] strings, CallbackInfo ci, @Local Services services, @Local LevelStorageSource.LevelStorageAccess levelStorageAccess, @Local DedicatedServerSettings dedicatedServerSettings) {
+        ConfigUpdater.tryUpdateOldVersion(levelStorageAccess, services, dedicatedServerSettings.getProperties().onlineMode);
     }
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/MinecraftMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/MinecraftMixin.java
@@ -37,7 +37,7 @@ public class MinecraftMixin {
         , @Local Services services
         //#endif
         ) {
-        ConfigUpdater.tryUpdateOldVersion(levelStorageAccess, services);
+        ConfigUpdater.tryUpdateOldVersion(levelStorageAccess, services, false);
     }
 
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
@@ -21,7 +21,7 @@ public class GameProfileUtil {
         try {
             GameProfileCache cache = server.getProfileCache();
             if (cache != null) {
-                gameprofile = server.getProfileCache().get(name).orElse(null);
+                gameprofile = cache.get(name).orElse(null);
             }
         } finally {
             GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());

--- a/versions/1.20.1/build.gradle
+++ b/versions/1.20.1/build.gradle
@@ -176,6 +176,7 @@ publishMods {
         versions.each {
             minecraftVersions.add(it)
         }
+        requires('carpet')
     }
 
     modrinth {
@@ -184,6 +185,7 @@ publishMods {
         versions.each {
             minecraftVersions.add(it)
         }
+        requires('carpet')
     }
 }
 

--- a/versions/1.20.1/build.gradle
+++ b/versions/1.20.1/build.gradle
@@ -164,7 +164,7 @@ java {
 publishMods {
     file = remapJar.archiveFile
     changelog = "Changelog"
-    type = BETA
+    type = STABLE
     modLoaders.add("fabric")
     modLoaders.add("quilt")
 


### PR DESCRIPTION
- 修复正版模式下假人驻留文件无法更新
- 配置文件更新逻辑目前为合并, 而不是之前的覆盖
- 修复`bot grop add/remove`命令报错
- 移除假人驻留旧配置文件的残留文件