### PR TITLE
假人补货问题 + seed命令权限控制

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - .github/workflows/**
       - src/**
       - versions/**
       - build.gradle
@@ -14,6 +15,8 @@ jobs:
   build:
     strategy:
       matrix:
+        java: [ 21 ]
+        distro: [ zulu ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     env:
@@ -21,33 +24,49 @@ jobs:
       PR_BUILD: false
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Setup Java 21
-        uses: actions/setup-java@v3.6.0
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v5
         with:
-          distribution: zulu
-          java-version: 21
+          distribution: ${{ matrix.distro }}
+          java-version: ${{ matrix.java }}
 
       - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@v5
 
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew build
 
+      - name: Collect build artifacts
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts
+          mkdir -p artifacts
+
+          while IFS= read -r -d '' f; do
+            cp -v "$f" artifacts/
+          done < <(
+            find . -type f -path "*/build/libs/*.jar" \
+            ! -name "*-sources.jar" \
+            -print0
+          )
+
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        if: ${{ runner.os == 'Linux' }}
+        uses: actions/upload-artifact@v7
         with:
-          name: build-artifacts
+          name: Artifacts
           path: |
-            */**/build/libs/
+            artifacts/
 
       - name: Publish
         if: ${{ startsWith(github.ref, 'refs/heads/releases/') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Mod Build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - releases/**
     paths:
       - src/**
       - versions/**
@@ -52,7 +50,7 @@ jobs:
             */**/build/libs/
 
       - name: Publish
-        if: ${{ !contains(github.event.head_commit.message, '- pass publish') }}
+        if: ${{ startsWith(github.ref, 'refs/heads/releases/') }}
         run: ./gradlew publishMods
         env:
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -133,10 +133,14 @@ Make fake player to auto fish. When the fishing hook catches a fish, it will aut
 
 Make fake player to auto replace almost damaged tool
 
-* Type: `boolean`
+* Type: `String`
 * Default: `false`
 * Options: `true`, `false`
-* Categories: `GCA`, `BOT`
+* Categories: `GCA`, `BOT`, `keep`
+
+> `true`: Tools with Mending will keep 10 durability; other tools will automatically switch after they break.
+
+> `keep`: All tools will keep 10 durability.
 
 ```
 /carpet fakePlayerAutoReplaceTool true

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Make fake player to auto replace almost damaged tool
 
 * Type: `String`
 * Default: `false`
-* Options: `true`, `false`
-* Categories: `GCA`, `BOT`, `keep`
+* Options: `true`, `false`, `keep`
+* Categories: `GCA`, `BOT`
 
 > `true`: Tools with Mending will keep 10 durability; other tools will automatically switch after they break.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -130,16 +130,20 @@
 
 ### 假人切换工具 (fakePlayerAutoReplaceTool)
 
-让假人自动切换快损坏的工具
+让假人自动切换损坏的工具
 
-* 类型: `boolean`
+* 类型: `String`
 * 默认值: `false`
-* 参考选项: `true`, `false`
+* 参考选项: `true`, `false`, `keep`
 * 分类: `GCA`, `BOT`
 
 ```
 /carpet fakePlayerAutoReplaceTool true
 ```
+
+> 当选项为 `true` 时有经验修补的工具会保留10点耐久, 其他在损坏后自动切换
+
+> 当选项为 `keep` 时所有工具都会保留10点耐久
 
 ### 假人名称前缀 (fakePlayerPrefixName)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 
 mod_id=gca
 mod_name=GugleCarpetAddition
-mod_version=2.11.2
+mod_version=2.11.3
 maven_group=dev.dubhe.gugle
 archives_base_name=gugle-carpet-addition
 

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -239,9 +239,9 @@ public class GcaSetting {
 
     // 允许玩家查看服务器种子
     @Rule(
-        options = {"vanilla", "true", "false", "ops", "0", "1", "2", "3", "4"},
+        options = {"true", "false", "ops", "0", "1", "2", "3", "4"},
         categories = {GCA, COMMAND},
         validators = Validators.CommandLevel.class
     )
-    public static String commandSeed = "vanilla";
+    public static String commandSeed = "ops";
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -239,9 +239,9 @@ public class GcaSetting {
 
     // 允许玩家查看服务器种子
     @Rule(
-        options = {"true", "false", "ops", "0", "1", "2", "3", "4"},
+        options = {"vanilla", "true", "false", "ops", "0", "1", "2", "3", "4"},
         categories = {GCA, COMMAND},
         validators = Validators.CommandLevel.class
     )
-    public static String commandSeed = "ops";
+    public static String commandSeed = "vanilla";
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -243,5 +243,5 @@ public class GcaSetting {
         categories = {GCA, COMMAND},
         validators = Validators.CommandLevel.class
     )
-    public static String commandSeed = "ops";
+    public static String commandSeed = "0";
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -62,7 +62,7 @@ public class GcaSetting {
     )
     public static boolean fakePlayerAutoFish = false;
 
-    // 让假人自动切换快损坏的工具
+    // 让假人自动切换工具
     @Rule(
         options = {"false", "true", "keep"},
         categories = {GCA, BOT}

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -239,9 +239,9 @@ public class GcaSetting {
 
     // 允许玩家查看服务器种子
     @Rule(
-        options = {"true", "false", "ops", "0", "1", "2", "3", "4"},
+        options = {"vanilla", "true", "false", "ops", "0", "1", "2", "3", "4"},
         categories = {GCA, COMMAND},
-        validators = Validators.CommandLevel.class
+        validators = GcaValidators.CommandLevelWithVanilla.class
     )
-    public static String commandSeed = "0";
+    public static String commandSeed = "vanilla";
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -64,9 +64,10 @@ public class GcaSetting {
 
     // 让假人自动切换快损坏的工具
     @Rule(
+        options = {"false", "true", "keep"},
         categories = {GCA, BOT}
     )
-    public static boolean fakePlayerAutoReplaceTool = false;
+    public static String fakePlayerAutoReplaceTool = "false";
 
     public static final String fakePlayerNoneName = "#none";
 

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -235,4 +235,12 @@ public class GcaSetting {
     //$$ )
     //$$ public static boolean fakePlayerLocatorBar = true;
     //#endif
+
+    // 允许玩家查看服务器种子
+    @Rule(
+        options = {"true", "false", "ops", "0", "1", "2", "3", "4"},
+        categories = {GCA, COMMAND},
+        validators = Validators.CommandLevel.class
+    )
+    public static String commandSeed = "ops";
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaValidators.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaValidators.java
@@ -25,6 +25,19 @@ public class GcaValidators {
         }
     }
 
+    public static class CommandLevelWithVanilla extends Validator<String> {
+        public static final List<String> OPTIONS = List.of("vanilla", "true", "false", "ops", "0", "1", "2", "3", "4");
+
+        @Override
+        public @Nullable String validate(@Nullable CommandSourceStack commandSourceStack, CarpetRule<String> carpetRule, String newValue, String userString) {
+            return OPTIONS.contains(newValue) ? newValue : null;
+        }
+
+        public String description() {
+            return "Can be limited to 'vanilla' or command level options";
+        }
+    }
+
     public static class CarpetAmsAdditionLoaded implements Rule.Condition {
         @Override
         public boolean shouldRegister() {

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
@@ -107,7 +107,7 @@ abstract class ItemStackMixin {
         // 在物品损坏前获取物品类型，损坏后将只能获取为空气
         Item item = itemStack.getItem();
         original.call(itemStack, i, source, serverPlayer, runnable);
-        if (GcaSetting.fakePlayerAutoReplaceTool && serverPlayer instanceof EntityPlayerMPFake fakePlayer) {
+        if (!"false".equals(GcaSetting.fakePlayerAutoReplaceTool) && serverPlayer instanceof EntityPlayerMPFake fakePlayer) {
             FakePlayerAutoReplaceTool.autoReplaceTool(fakePlayer, item, equipmentSlot);
         }
     }
@@ -119,7 +119,7 @@ abstract class ItemStackMixin {
     //$$         // 物品耐久耗尽，交给下方的Mixin方法处理
     //$$         return true;
     //$$     }
-    //$$     if (GcaSetting.fakePlayerAutoReplaceTool && player instanceof EntityPlayerMPFake fakePlayer) {
+    //$$     if (!"false".equals(GcaSetting.fakePlayerAutoReplaceTool) && player instanceof EntityPlayerMPFake fakePlayer) {
     //$$         FakePlayerAutoReplaceTool.autoReplaceTool(fakePlayer, itemStack.getItem(), itemStack);
     //$$     }
     //$$     return false;
@@ -129,7 +129,7 @@ abstract class ItemStackMixin {
     //$$ private <T extends LivingEntity> void onShrink(ItemStack itemStack, int i, Operation<Void> original, @Local(argsOnly = true) T livingEntity) {
     //$$     Item item = itemStack.getItem();
     //$$     original.call(itemStack, i);
-    //$$     if (GcaSetting.fakePlayerAutoReplaceTool && livingEntity instanceof EntityPlayerMPFake fakePlayer) {
+    //$$     if (!"false".equals(GcaSetting.fakePlayerAutoReplaceTool) && livingEntity instanceof EntityPlayerMPFake fakePlayer) {
     //$$         FakePlayerAutoReplaceTool.autoReplaceTool(fakePlayer, item, itemStack);
     //$$     }
     //$$ }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ParsedRuleMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ParsedRuleMixin.java
@@ -1,0 +1,23 @@
+package dev.dubhe.gugle.carpet.mixin;
+
+import carpet.settings.ParsedRule;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.dubhe.gugle.carpet.GcaValidators;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+@SuppressWarnings("removal")
+@Mixin(value = ParsedRule.class, remap = false)
+public class ParsedRuleMixin {
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 1))
+    private <E> boolean onAdd(List<E> list, E e, Operation<Boolean> original) {
+        if (list.stream().anyMatch(it -> it.getClass() == GcaValidators.CommandLevelWithVanilla.class)) {
+            return false;
+        }
+        return original.call(list, e);
+    }
+
+}

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
@@ -16,7 +16,9 @@ import java.util.function.Predicate;
 @Mixin(SeedCommand.class)
 public class SeedCommandMixin {
     @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
-    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate predicate, Operation<ArgumentBuilder> original) {
-        return original.call(instance, (Predicate<CommandSourceStack>) stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed));
+    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate<CommandSourceStack> predicate, Operation<ArgumentBuilder> original) {
+        Predicate<CommandSourceStack> permissionCheck = stack -> "0".equals(GcaSetting.commandSeed) ?
+            predicate.test(stack) : CommandHelper.canUseCommand(stack, GcaSetting.commandSeed);
+        return original.call(instance, permissionCheck);
     }
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
@@ -17,7 +17,7 @@ import java.util.function.Predicate;
 public class SeedCommandMixin {
     @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
     private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate<CommandSourceStack> predicate, Operation<ArgumentBuilder> original) {
-        Predicate<CommandSourceStack> permissionCheck = stack -> "0".equals(GcaSetting.commandSeed) ?
+        Predicate<CommandSourceStack> permissionCheck = stack -> "vanilla".equals(GcaSetting.commandSeed) ?
             predicate.test(stack) : CommandHelper.canUseCommand(stack, GcaSetting.commandSeed);
         return original.call(instance, permissionCheck);
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
@@ -16,7 +16,9 @@ import java.util.function.Predicate;
 @Mixin(SeedCommand.class)
 public class SeedCommandMixin {
     @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
-    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate predicate, Operation<ArgumentBuilder> original) {
-        return original.call(instance, (Predicate<CommandSourceStack>) stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed));
+    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate<CommandSourceStack> predicate, Operation<ArgumentBuilder> original) {
+        Predicate<CommandSourceStack> permissionCheck = "vanilla".equals(GcaSetting.commandSeed) ?
+            predicate : stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed);
+        return original.call(instance, permissionCheck);
     }
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
@@ -16,9 +16,7 @@ import java.util.function.Predicate;
 @Mixin(SeedCommand.class)
 public class SeedCommandMixin {
     @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
-    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate<CommandSourceStack> predicate, Operation<ArgumentBuilder> original) {
-        Predicate<CommandSourceStack> permissionCheck = "vanilla".equals(GcaSetting.commandSeed) ?
-            predicate : stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed);
-        return original.call(instance, permissionCheck);
+    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate predicate, Operation<ArgumentBuilder> original) {
+        return original.call(instance, (Predicate<CommandSourceStack>) stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed));
     }
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/SeedCommandMixin.java
@@ -1,0 +1,22 @@
+package dev.dubhe.gugle.carpet.mixin;
+
+import carpet.utils.CommandHelper;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.dubhe.gugle.carpet.GcaSetting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.commands.SeedCommand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.Predicate;
+
+@Mixin(SeedCommand.class)
+public class SeedCommandMixin {
+    @WrapOperation(method = "register", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;requires(Ljava/util/function/Predicate;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", remap = false))
+    private static ArgumentBuilder modify(LiteralArgumentBuilder instance, Predicate predicate, Operation<ArgumentBuilder> original) {
+        return original.call(instance, (Predicate<CommandSourceStack>) stack -> CommandHelper.canUseCommand(stack, GcaSetting.commandSeed));
+    }
+}

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
@@ -1,17 +1,17 @@
 package dev.dubhe.gugle.carpet.tools.player;
 
+import dev.dubhe.gugle.carpet.GcaSetting;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
-
 
 import java.util.function.Predicate;
 
 //#if MC >= 12100
 import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.item.enchantment.Enchantment;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
@@ -22,7 +22,15 @@ import net.minecraft.core.Holder;
 //#endif
 
 //#if MC < 12005
+//$$ import net.minecraft.nbt.CompoundTag;
+//$$ import net.minecraft.nbt.ListTag;
+//$$ import net.minecraft.nbt.Tag;
 //$$ import java.util.Optional;
+//#else
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.component.ItemContainerContents;
+import java.util.List;
+import java.util.stream.Collectors;
 //#endif
 
 public class FakePlayerAutoReplaceTool {
@@ -35,8 +43,7 @@ public class FakePlayerAutoReplaceTool {
     //#endif
         Predicate<ItemStack> isDamageItem = itemDamagePredicate();
         if (isDamageItem.test(itemStack)) {
-            //#if MC>=12005
-            //#else
+            //#if MC < 12005
             //$$ Optional<EquipmentSlot> optional = getEquipmentSlot(fakePlayer, itemStack);
             //$$ if (optional.isEmpty()) {
             //$$     return;
@@ -72,6 +79,7 @@ public class FakePlayerAutoReplaceTool {
             return true;
         }
         Inventory inventory = fakePlayer.getInventory();
+        // 从背包补货
         for (int i = 0; i < inventory.getContainerSize(); i++) {
             ItemStack itemStack = inventory.getItem(i);
             if (itemStack.isEmpty()) {
@@ -85,17 +93,57 @@ public class FakePlayerAutoReplaceTool {
                 return true;
             }
         }
+        // 从潜影盒补货
+        if (!GcaSetting.fakePlayerAutoReplenishmentFormShulkerBox) return false;
+
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack itemStack = inventory.getItem(i);
+            if (!itemStack.is(Items.SHULKER_BOX)) continue;
+            //#if MC>=12005
+            ItemContainerContents contents = itemStack.get(DataComponents.CONTAINER);
+            if (contents == null) continue;
+            List<ItemStack> items = contents.stream().collect(Collectors.toList());
+            for (int index = 0; index < items.size(); index++) {
+                ItemStack item = items.get(index);
+                if (predicate.test(item)) {
+                    ItemStack itemBySlot = fakePlayer.getItemBySlot(slot);
+                    ItemStack copy = item.copy();
+                    items.set(index, itemBySlot);
+                    fakePlayer.setItemSlot(slot, copy);
+                    itemStack.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(items));
+                    return true;
+                }
+            }
+            //#else
+            //$$ CompoundTag nbt = itemStack.getTagElement("BlockEntityTag");
+            //$$ if (nbt == null || !nbt.contains("Items", Tag.TAG_LIST)) return false;
+            //$$ ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
+            //$$ for (int index = 0; index < tagList.size(); index++) {
+            //$$     CompoundTag tag = tagList.getCompound(index);
+            //$$     ItemStack stack = ItemStack.of(tag);
+            //$$     if (predicate.test(stack)) {
+            //$$         ItemStack itemBySlot = fakePlayer.getItemBySlot(slot);
+            //$$         ItemStack copy = stack.copy();
+            //$$         fakePlayer.setItemSlot(slot, copy);
+            //$$         CompoundTag newTag = itemBySlot.save(new CompoundTag());
+            //$$         newTag.putByte("Slot", tag.getByte("Slot"));
+            //$$         tagList.set(index, newTag);
+            //$$     }
+            //$$ }
+            //#endif
+        }
         return false;
     }
 
     private static Predicate<ItemStack> itemDamagePredicate() {
+        boolean keepTool = "keep".equals(GcaSetting.fakePlayerAutoReplaceTool);
         return itemStack -> {
             if (itemStack.isEmpty()) {
                 return true;
             }
             if (itemStack.isDamageableItem()) {
                 // 有经验修补的物品，保留10点耐久
-                if (hasMending(itemStack)) {
+                if (keepTool || hasMending(itemStack)) {
                     int remaining = itemStack.getMaxDamage() - itemStack.getDamageValue();
                     return remaining <= 10;
                 }
@@ -106,9 +154,10 @@ public class FakePlayerAutoReplaceTool {
     }
 
     private static Predicate<ItemStack> itemReplacePredicate(Item item) {
+        boolean keepTool = "keep".equals(GcaSetting.fakePlayerAutoReplaceTool);
         return itemStack -> {
             if (itemStack.getItem().getClass() == item.getClass()) {
-                if (hasMending(itemStack)) {
+                if (keepTool || hasMending(itemStack)) {
                     return itemStack.getMaxDamage() - itemStack.getDamageValue() > 10;
                 }
                 return true;

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
@@ -116,7 +116,7 @@ public class FakePlayerAutoReplaceTool {
             }
             //#else
             //$$ CompoundTag nbt = itemStack.getTagElement("BlockEntityTag");
-            //$$ if (nbt == null || !nbt.contains("Items", Tag.TAG_LIST)) return false;
+            //$$ if (nbt == null || !nbt.contains("Items", Tag.TAG_LIST)) continue;
             //$$ ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
             //$$ for (int index = 0; index < tagList.size(); index++) {
             //$$     CompoundTag tag = tagList.getCompound(index);
@@ -128,6 +128,7 @@ public class FakePlayerAutoReplaceTool {
             //$$         CompoundTag newTag = itemBySlot.save(new CompoundTag());
             //$$         newTag.putByte("Slot", tag.getByte("Slot"));
             //$$         tagList.set(index, newTag);
+            //$$         return true;
             //$$     }
             //$$ }
             //#endif

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
@@ -1,11 +1,11 @@
 package dev.dubhe.gugle.carpet.tools.player;
 
 import dev.dubhe.gugle.carpet.GcaSetting;
+import dev.dubhe.gugle.carpet.util.ContainerUtil;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.function.Predicate;
@@ -98,7 +98,7 @@ public class FakePlayerAutoReplaceTool {
 
         for (int i = 0; i < inventory.getContainerSize(); i++) {
             ItemStack itemStack = inventory.getItem(i);
-            if (!itemStack.is(Items.SHULKER_BOX)) continue;
+            if (!ContainerUtil.hasContainer(itemStack)) continue;
             //#if MC>=12005
             ItemContainerContents contents = itemStack.get(DataComponents.CONTAINER);
             if (contents == null) continue;
@@ -110,26 +110,33 @@ public class FakePlayerAutoReplaceTool {
                     ItemStack copy = item.copy();
                     items.set(index, itemBySlot);
                     fakePlayer.setItemSlot(slot, copy);
-                    itemStack.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(items));
+                    ItemContainerContents container = items.stream().allMatch(ItemStack::isEmpty) ?
+                        ItemContainerContents.EMPTY :
+                        ItemContainerContents.fromItems(items);
+                    itemStack.set(DataComponents.CONTAINER, container);
                     return true;
                 }
             }
             //#else
             //$$ CompoundTag nbt = itemStack.getTagElement("BlockEntityTag");
-            //$$ if (nbt == null || !nbt.contains("Items", Tag.TAG_LIST)) continue;
+            //$$ if (nbt == null) continue;
             //$$ ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
             //$$ for (int index = 0; index < tagList.size(); index++) {
             //$$     CompoundTag tag = tagList.getCompound(index);
             //$$     ItemStack stack = ItemStack.of(tag);
-            //$$     if (predicate.test(stack)) {
-            //$$         ItemStack itemBySlot = fakePlayer.getItemBySlot(slot);
-            //$$         ItemStack copy = stack.copy();
-            //$$         fakePlayer.setItemSlot(slot, copy);
-            //$$         CompoundTag newTag = itemBySlot.save(new CompoundTag());
-            //$$         newTag.putByte("Slot", tag.getByte("Slot"));
-            //$$         tagList.set(index, newTag);
+            //$$     if (!predicate.test(stack)) continue;
+            //$$     ItemStack itemBySlot = fakePlayer.getItemBySlot(slot);
+            //$$     ItemStack copy = stack.copy();
+            //$$     fakePlayer.setItemSlot(slot, copy);
+            //$$     if (itemBySlot.isEmpty()) {
+            //$$         tagList.remove(index);
+            //$$         if (tagList.isEmpty()) nbt.remove("Items");
             //$$         return true;
             //$$     }
+            //$$     CompoundTag newTag = itemBySlot.save(new CompoundTag());
+            //$$     newTag.putByte("Slot", tag.getByte("Slot"));
+            //$$     tagList.set(index, newTag);
+            //$$     return true;
             //$$ }
             //#endif
         }

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplenishment.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplenishment.java
@@ -1,6 +1,7 @@
 package dev.dubhe.gugle.carpet.tools.player;
 
 import dev.dubhe.gugle.carpet.GcaSetting;
+import dev.dubhe.gugle.carpet.util.ContainerUtil;
 import dev.dubhe.gugle.carpet.util.InventoryUtil;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.InteractionHand;
@@ -49,7 +50,7 @@ public class FakePlayerAutoReplenishment {
                     eachItem.setCount(0);
                 }
                 break;
-            } else if (GcaSetting.fakePlayerAutoReplenishmentFormShulkerBox && hasContainer(eachItem)) {
+            } else if (GcaSetting.fakePlayerAutoReplenishmentFormShulkerBox && ContainerUtil.hasContainer(eachItem)) {
                 int result = pickItemFromBox(eachItem, itemStack, half);
                 if (result == 0) {
                     continue;
@@ -58,16 +59,6 @@ public class FakePlayerAutoReplenishment {
                 return;
             }
         }
-    }
-
-    private static boolean hasContainer(ItemStack stack) {
-        //#if MC>=12005
-        return stack.has(DataComponents.CONTAINER);
-        //#else
-        //$$ CompoundTag tag = stack.getTag();
-        //$$ if (tag == null) return false;
-        //$$ return tag.contains("BlockEntityTag") && tag.getCompound("BlockEntityTag").contains("Items", Tag.TAG_LIST);
-        //#endif
     }
 
     // 从潜影盒拿取物品，请注意：在创造模式下使用鼠标中键复制物品（不是指选取方块）时，物品组件仅被浅拷贝。
@@ -134,19 +125,4 @@ public class FakePlayerAutoReplenishment {
         //#endif
     }
 
-    // 如果潜影盒为空，将物品栏组件替换为空以保证潜影盒堆叠的正常运行
-    //#if MC>=12005
-    private static void ifIsEmptyClear(ItemStack shulkerBox) {
-        ItemContainerContents contents = shulkerBox.get(DataComponents.CONTAINER);
-        if (contents == null) {
-            return;
-        }
-        // 潜影盒中还有物品
-        if (contents.nonEmptyItems().iterator().hasNext()) {
-            return;
-        }
-        // 潜影盒中已经没有物品了
-        shulkerBox.set(DataComponents.CONTAINER, ItemContainerContents.EMPTY);
-    }
-    //#endif
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplenishment.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplenishment.java
@@ -11,6 +11,8 @@ import net.minecraft.world.item.ItemStack;
 //#if MC>=12005
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.component.ItemContainerContents;
+
+import java.util.List;
 //#else
 //$$ import net.minecraft.nbt.CompoundTag;
 //$$ import net.minecraft.nbt.Tag;
@@ -69,25 +71,38 @@ public class FakePlayerAutoReplenishment {
     }
 
     // 从潜影盒拿取物品，请注意：在创造模式下使用鼠标中键复制物品（不是指选取方块）时，物品组件仅被浅拷贝。
-    private static int pickItemFromBox(ItemStack shulkerBox, ItemStack itemStack, int count) {
+    private static int pickItemFromBox(ItemStack shulkerBox, ItemStack itemStack, int requestCount) {
         //#if MC>=12005
         ItemContainerContents contents = shulkerBox.get(DataComponents.CONTAINER);
-        if (contents == null) return 0;
-        // 潜影盒没有容器组件
-        for (ItemStack stack : contents.nonEmptyItems()) {
+        // 空的潜影盒
+        if (contents == null || contents == ItemContainerContents.EMPTY) return 0;
+        // 深拷贝
+        List<ItemStack> list = contents.stream().toList();
+        int count = 0;
+
+        for (ItemStack stack : list) {
             if (ItemStack.isSameItemSameComponents(itemStack, stack)) {
-                int temp;
-                if (stack.getCount() >= count) {
-                    stack.shrink(count);
-                    temp = count;
+                if (stack.getCount() >= requestCount) {
+                    stack.shrink(requestCount);
+                    count = requestCount;
                 } else {
-                    temp = stack.getCount();
+                    count = stack.getCount();
                     stack.setCount(0);
                 }
-                ifIsEmptyClear(shulkerBox);
-                return temp;
+                break;
             }
         }
+
+        if (count > 0) {
+            // 将深拷贝的组件写回潜影盒
+            shulkerBox.set(DataComponents.CONTAINER,
+                list.stream().allMatch(ItemStack::isEmpty) ?
+                    ItemContainerContents.EMPTY :
+                    ItemContainerContents.fromItems(list)
+            );
+        }
+
+        return count;
         //#else
         //$$ CompoundTag nbt = shulkerBox.getTagElement("BlockEntityTag");
         //$$ if (nbt == null || !nbt.contains("Items", Tag.TAG_LIST)) return 0;
@@ -101,9 +116,9 @@ public class FakePlayerAutoReplenishment {
         //$$     CompoundTag tag = next.getId() == 10 ? (CompoundTag) next : new CompoundTag();
         //$$     ItemStack stack = ItemStack.of(tag);
         //$$     if (!ItemStack.isSameItemSameTags(stack, itemStack)) continue;
-        //$$     if (stack.getCount() > count) {
-        //$$         temp = count;
-        //$$         stack.shrink(count);
+        //$$     if (stack.getCount() > requestCount) {
+        //$$         temp = requestCount;
+        //$$         stack.shrink(requestCount);
         //$$     } else {
         //$$         temp = stack.getCount();
         //$$         stack.setCount(0);
@@ -115,8 +130,8 @@ public class FakePlayerAutoReplenishment {
         //$$     } else iterator.remove();
         //$$     return temp;
         //$$ }
+        //$$ return 0;
         //#endif
-        return 0;
     }
 
     // 如果潜影盒为空，将物品栏组件替换为空以保证潜影盒堆叠的正常运行

--- a/src/main/java/dev/dubhe/gugle/carpet/util/ContainerUtil.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/util/ContainerUtil.java
@@ -1,0 +1,22 @@
+package dev.dubhe.gugle.carpet.util;
+
+import net.minecraft.world.item.ItemStack;
+//#if MC < 12005
+//$$ import net.minecraft.nbt.CompoundTag;
+//$$ import net.minecraft.nbt.Tag;
+//#else
+import net.minecraft.core.component.DataComponents;
+//#endif
+
+public class ContainerUtil {
+    public static boolean hasContainer(ItemStack stack) {
+        //#if MC>=12005
+        return stack.has(DataComponents.CONTAINER);
+        //#else
+        //$$ CompoundTag tag = stack.getTag();
+        //$$ if (tag == null) return false;
+        //$$ return tag.contains("BlockEntityTag") && tag.getCompound("BlockEntityTag").contains("Items", Tag.TAG_LIST);
+        //#endif
+    }
+
+}

--- a/src/main/resources/assets/gca/lang/en_us.json
+++ b/src/main/resources/assets/gca/lang/en_us.json
@@ -27,7 +27,7 @@
   "carpet.rule.fakePlayerAutoFish.desc": "Make fake player to auto fish",
 
   "carpet.rule.fakePlayerAutoReplaceTool.name": "Fake Player Auto Replace Tool",
-  "carpet.rule.fakePlayerAutoReplaceTool.desc": "Make fake player to auto replace almost damaged tool",
+  "carpet.rule.fakePlayerAutoReplaceTool.desc": "Make fake player to auto replace damaged tool",
 
   "carpet.rule.betterFenceGatePlacement.name": "Better Fence Gate Placement",
   "carpet.rule.betterFenceGatePlacement.desc": "Make the placed fence gate have the same block status as the fence gate you clicked",

--- a/src/main/resources/assets/gca/lang/en_us.json
+++ b/src/main/resources/assets/gca/lang/en_us.json
@@ -110,6 +110,9 @@
   "carpet.rule.fakePlayerLocatorBar.name": "Fake Player LocatorBar",
   "carpet.rule.fakePlayerLocatorBar.desc": "Display Fake Player Positions On The Locator Bar",
 
+  "carpet.rule.commandSeed.name": "Command Seed",
+  "carpet.rule.commandSeed.desc": "/seed command",
+
   "gca.action.attack.interval.12": "Attack every 12 gt: %s",
   "gca.action.attack.continuous": "Attack continuous: %s",
   "gca.action.use.continuous": "Use continuous: %s",

--- a/src/main/resources/assets/gca/lang/en_us.json
+++ b/src/main/resources/assets/gca/lang/en_us.json
@@ -111,7 +111,7 @@
   "carpet.rule.fakePlayerLocatorBar.desc": "Display Fake Player Positions On The Locator Bar",
 
   "carpet.rule.commandSeed.name": "Command Seed",
-  "carpet.rule.commandSeed.desc": "/seed command",
+  "carpet.rule.commandSeed.desc": "Sets the required permission level for the /seed command",
 
   "gca.action.attack.interval.12": "Attack every 12 gt: %s",
   "gca.action.attack.continuous": "Attack continuous: %s",

--- a/src/main/resources/assets/gca/lang/zh_cn.json
+++ b/src/main/resources/assets/gca/lang/zh_cn.json
@@ -27,7 +27,7 @@
   "carpet.rule.fakePlayerAutoFish.desc": "让假人自动钓鱼",
 
   "carpet.rule.fakePlayerAutoReplaceTool.name": "假人切换工具",
-  "carpet.rule.fakePlayerAutoReplaceTool.desc": "让假人自动切换快损坏的工具",
+  "carpet.rule.fakePlayerAutoReplaceTool.desc": "让假人自动切换损坏的工具",
 
   "carpet.rule.betterFenceGatePlacement.name": "更好的栅栏门放置",
   "carpet.rule.betterFenceGatePlacement.desc": "让放置的栅栏门与你点击的栅栏门拥有相同的方块状态",

--- a/src/main/resources/assets/gca/lang/zh_cn.json
+++ b/src/main/resources/assets/gca/lang/zh_cn.json
@@ -110,6 +110,9 @@
   "carpet.rule.fakePlayerLocatorBar.name": "假人定位条",
   "carpet.rule.fakePlayerLocatorBar.desc": "在定位条上显示假玩家位置",
 
+  "carpet.rule.commandSeed.name": "seed命令",
+  "carpet.rule.commandSeed.desc": "修改/seed命令的权限等级",
+
   "gca.action.attack.interval.12": "间隔 12 gt攻击：%s",
   "gca.action.attack.continuous": "一直左键： %s",
   "gca.action.use.continuous": "一直右键：%s",

--- a/src/main/resources/assets/gca/lang/zh_tw.json
+++ b/src/main/resources/assets/gca/lang/zh_tw.json
@@ -110,6 +110,9 @@
   "carpet.rule.fakePlayerLocatorBar.name": "Fake Player LocatorBar",
   "carpet.rule.fakePlayerLocatorBar.desc": "Display Fake Player Positions On The Locator Bar",
 
+  "carpet.rule.commandSeed.name": "Command Seed",
+  "carpet.rule.commandSeed.desc": "/seed command",
+
   "gca.action.attack.interval.12": "間隔 12 gt攻擊：%s",
   "gca.action.attack.continuous": "連續攻擊：%s",
   "gca.action.use.continuous": "連續使用：%s",

--- a/src/main/resources/assets/gca/lang/zh_tw.json
+++ b/src/main/resources/assets/gca/lang/zh_tw.json
@@ -111,7 +111,7 @@
   "carpet.rule.fakePlayerLocatorBar.desc": "Display Fake Player Positions On The Locator Bar",
 
   "carpet.rule.commandSeed.name": "Command Seed",
-  "carpet.rule.commandSeed.desc": "/seed command",
+  "carpet.rule.commandSeed.desc": "Sets the required permission level for the /seed command",
 
   "gca.action.attack.interval.12": "間隔 12 gt攻擊：%s",
   "gca.action.attack.continuous": "連續攻擊：%s",

--- a/src/main/resources/assets/gca/lang/zh_tw.json
+++ b/src/main/resources/assets/gca/lang/zh_tw.json
@@ -24,7 +24,7 @@
   "carpet.rule.fakePlayerAutoFish.desc": "讓假人自動釣魚",
 
   "carpet.rule.fakePlayerAutoReplaceTool.name": "假人自動切換工具",
-  "carpet.rule.fakePlayerAutoReplaceTool.desc": "讓假人自動替換快損壞的工具",
+  "carpet.rule.fakePlayerAutoReplaceTool.desc": "讓假人自動替換損壞的工具",
 
   "carpet.rule.betterFenceGatePlacement.name": "更好的柵欄門放置",
   "carpet.rule.betterFenceGatePlacement.desc": "讓放置的柵欄門具有與您點擊的柵欄門相同的方塊狀態",

--- a/src/main/resources/gca.mixins.json
+++ b/src/main/resources/gca.mixins.json
@@ -25,6 +25,7 @@
     "PlayerAccessor",
     "PlayerCommandMixin",
     "PlayerMixin",
+    "SeedCommandMixin",
     "ServerGamePacketListenerImplMixin",
     "ServerLevelMixin",
     "ServerPlaceRecipeMixin",

--- a/src/main/resources/gca.mixins.json
+++ b/src/main/resources/gca.mixins.json
@@ -22,6 +22,7 @@
     "MainServerMixin",
     "MinecraftServerMixin",
     "NaturalSpawnerMixin",
+    "ParsedRuleMixin",
     "PlayerAccessor",
     "PlayerCommandMixin",
     "PlayerMixin",


### PR DESCRIPTION
- 修复浅拷贝导致的物品同步问题
- 假人可以从潜影盒中补充工具
- 假人自动切换快工具新增`keep`选项, 无论工具是否有经验修补附魔都会保留10点耐久
- 更新`fakePlayerAutoReplaceTool`的文本表述
- 新增commandSeed选项, 可以控制seed命令的执行权限