### PR TITLE
2.12.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,1 @@
-- Add fake player action management.
-  - `/bot action <bot> <list|add|remove>`
-- Added the `fakePlayerToolDamagedNotification` option, which broadcasts a server-wide notification when a tool breaks or restocking fails.
-- Fix an issue where FakePlayerResident data would be wiped when saved during server shutdown on mc version 26.1+.
+- Fixed an issue where saving FakePlayerResident data would clear the fake player's ongoing actions when fakePlayerResident is enabled and fakePlayerReloadAction is disabled.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,1 @@
-- Fixed an issue where saving FakePlayerResident data would clear the fake player's ongoing actions when fakePlayerResident is enabled and fakePlayerReloadAction is disabled.
+- Fixed an issue where saving FakePlayerResident data would clear the fake player's ongoing actions when `fakePlayerResident` is enabled and `fakePlayerReloadAction` is disabled.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,2 @@
 - Fixed an issue where saving FakePlayerResident data would clear the fake player's ongoing actions when `fakePlayerResident` is enabled and `fakePlayerReloadAction` is disabled.
+- `fakePlayerReloadAction` default true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ mod_name=GugleCarpetAddition
 archives_base_name=gugle-carpet-addition
 maven_group=dev.dubhe.gugle
 
-mod_version=2.12.0
+mod_version=2.12.1
 mc_version_range=1.20 26.1.2
 
 loom_version=1.15-SNAPSHOT

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -42,7 +42,7 @@ public class GcaSetting {
     @Rule(
         categories = {GCA, BOT}
     )
-    public static boolean fakePlayerReloadAction = false;
+    public static boolean fakePlayerReloadAction = true;
 
     // 让假人自动补货
     @Rule(

--- a/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/commands/BotCommand.java
@@ -479,7 +479,7 @@ public class BotCommand {
                 source.sendFailure(ComponentHelper.fmtHlt("Bot %s already exists.", botName));
                 continue;
             }
-            BotInfo bot = BotInfo.create(botName, botName, player, new EntityPlayerActionPack(player));
+            BotInfo bot = BotInfo.create(botName, botName, player, null);
             BOT_CONFIG.update(bot, false);
             bots.add(bot);
         }

--- a/src/main/java/dev/dubhe/gugle/carpet/config/updater/package-info.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/config/updater/package-info.java
@@ -1,0 +1,9 @@
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package dev.dubhe.gugle.carpet.config.updater;
+
+import dev.dubhe.gugle.carpet.api.annotations.FieldsAreNonnullByDefault;
+import dev.dubhe.gugle.carpet.api.annotations.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/gugle/carpet/entry/BotActionInfo.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/entry/BotActionInfo.java
@@ -7,6 +7,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.dubhe.gugle.carpet.mixin.APAccessor;
 import dev.dubhe.gugle.carpet.mixin.ActionAccessor;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 
 public record BotActionInfo(
     boolean sneaking,
@@ -29,7 +30,8 @@ public record BotActionInfo(
 
     public static final BotActionInfo EMPTY = new BotActionInfo(false, false, 0F, 0F, 0, 0, 0);
 
-    public static BotActionInfo fromActionPack(EntityPlayerActionPack pack) {
+    public static BotActionInfo fromActionPack(@Nullable EntityPlayerActionPack pack) {
+        if (pack == null) return EMPTY;
         APAccessor accessor = (APAccessor) pack;
         return new BotActionInfo(
             accessor.getSneaking(),

--- a/src/main/java/dev/dubhe/gugle/carpet/entry/BotInfo.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/entry/BotInfo.java
@@ -61,13 +61,11 @@ public record BotInfo(
 
     public static BotInfo create(ServerPlayer player, String desc, boolean saveAction) {
         String name = player.getGameProfile().getName();
-        EntityPlayerActionPack actionPack = saveAction ?
-            ((ServerPlayerInterface) player).getActionPack() :
-            new EntityPlayerActionPack(player);
+        EntityPlayerActionPack actionPack = saveAction ? ((ServerPlayerInterface) player).getActionPack() : null;
         return BotInfo.create(name, desc, player, actionPack);
     }
 
-    public static BotInfo create(String name, String desc, ServerPlayer player, EntityPlayerActionPack actionPack) {
+    public static BotInfo create(String name, String desc, ServerPlayer player, @Nullable EntityPlayerActionPack actionPack) {
         return new BotInfo(
             name,
             desc,

--- a/src/main/java/dev/dubhe/gugle/carpet/settings/package-info.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/settings/package-info.java
@@ -1,0 +1,9 @@
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package dev.dubhe.gugle.carpet.settings;
+
+import dev.dubhe.gugle.carpet.api.annotations.FieldsAreNonnullByDefault;
+import dev.dubhe.gugle.carpet.api.annotations.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -1,3 +1,3 @@
-minecraft_version=1.21
+minecraft_version=1.21.1
 minecraft_support_version=>=1.21- <1.21.2-
 carpet_core_version=1.21-1.4.147+v240613

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -1,3 +1,3 @@
-minecraft_version=1.21.1
+minecraft_version=1.21
 minecraft_support_version=>=1.21- <1.21.2-
 carpet_core_version=1.21-1.4.147+v240613


### PR DESCRIPTION
- 修复启用`fakePlayerResident`且禁用`fakePlayerReloadAction`时, 在保存假人驻留信息时会清空假人正在进行的动作
- 假人驻留保留假人动作(`fakePlayerReloadAction`) 默认设为true