### PR TITLE
v2.12.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,4 @@
-- Fixed an issue where saving FakePlayerResident data would clear the fake player's ongoing actions when `fakePlayerResident` is enabled and `fakePlayerReloadAction` is disabled.
-- `fakePlayerReloadAction` default true
+- Use `en_us` as the default i18n text.
+- Update tool restocking conditions to support newer versions;
+  - now restocks same items instead of similar ones.
+- Adjust restocking timing to trigger earlier, accommodating more use cases.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,3 +2,5 @@
 - Update tool restocking conditions to support newer versions;
   - now restocks same items instead of similar ones.
 - Adjust restocking timing to trigger earlier, accommodating more use cases.
+- Added `fakePlayerForceOfflineUUID` option
+  - `allowSpawningOfflinePlayers` must be `true`, otherwise the fake player cannot be spawned.

--- a/README_cn.md
+++ b/README_cn.md
@@ -4,6 +4,8 @@
 [![CurseForge downloads](http://cf.way2muchnoise.eu/full_662867_downloads.svg)](https://www.curseforge.com/minecraft/mc-mods/guglecarpetaddition)
 [![Modrinth downloads](https://img.shields.io/modrinth/dt/gca?color=00AF5C&label=Modrinth%20downloads&logo=modrinth)](https://modrinth.com/mod/gca)
 [![GitHub downloads](https://img.shields.io/github/downloads/Gu-ZT/gugle-carpet-addition/total?label=Github%20downloads&logo=github)](https://github.com/Gu-ZT/gugle-carpet-addition/releases)
+[![Static Badge](https://img.shields.io/badge/%E7%BE%A4-255072087-73c465?logo=QQ)](https://qm.qq.com/q/XxElk1U6As)
+
 ![menu](docs/pics/menu_zh.png)
 
 ## GCA

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,15 +6,15 @@ mod_name=GugleCarpetAddition
 archives_base_name=gugle-carpet-addition
 maven_group=dev.dubhe.gugle
 
-mod_version=2.12.1
+mod_version=2.12.2
 mc_version_range=1.20 26.1.2
 
-loom_version=1.15-SNAPSHOT
+loom_version=1.16-SNAPSHOT
 preprocessor_version=c5abb4fb12
-loader_version=0.18.4
+loader_version=0.19.2
 mixinextras_version=0.4.1
 
-release_channel=release
+release_channel=beta
 required_mods=carpet
 curseforge_id=662867
 modrinth_id=UHjbX5mk

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -91,6 +91,12 @@ public class GcaSetting {
     )
     public static String fakePlayerSuffixName = fakePlayerNoneName;
 
+//    // 假人强制使用离线uuid
+//    @Rule(
+//        categories = {GCA, BOT}
+//    )
+//    public static boolean fakePlayerForceOfflineUUID = false;
+
     // 方便快捷的假人管理菜单
     @Rule(
         categories = {GCA, BOT, COMMAND},

--- a/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/GcaSetting.java
@@ -91,11 +91,11 @@ public class GcaSetting {
     )
     public static String fakePlayerSuffixName = fakePlayerNoneName;
 
-//    // 假人强制使用离线uuid
-//    @Rule(
-//        categories = {GCA, BOT}
-//    )
-//    public static boolean fakePlayerForceOfflineUUID = false;
+    // 假人强制使用离线uuid
+    @Rule(
+        categories = {GCA, BOT}
+    )
+    public static boolean fakePlayerForceOfflineUUID = false;
 
     // 方便快捷的假人管理菜单
     @Rule(

--- a/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
@@ -33,13 +33,7 @@ public class ComponentHelper {
         if (text == null) {
             text = en_us.get(key);
         }
-        // 不太懂这里为什么要try catch
-        try {
-            return Component.translatableWithFallback(key, text, args).setStyle(style);
-        } catch (ClassCastException | NullPointerException e) {
-            GcaExtension.LOGGER.error(e.getMessage(), e);
-            return Component.translatable(key, args);
-        }
+        return Component.translatableWithFallback(key, text, args).setStyle(style);
     }
 
     @SuppressWarnings("NoTranslation")

--- a/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
@@ -17,6 +17,7 @@ public class ComponentHelper {
 
     private static String lang = "";
     private static final Map<String, String> language = new HashMap<>();
+    private static final Map<String, String> en_us = new HashMap<>();
 
     public static Component tr(String key, Object... args) {
         return tr(key, null, args);
@@ -28,9 +29,13 @@ public class ComponentHelper {
 
     public static Component tr(String key, @Nullable TextColor color, Style style, Object... args) {
         if (color != null) style = style.withColor(color);
+        String text = language.get(key);
+        if (text == null) {
+            text = en_us.get(key);
+        }
         // 不太懂这里为什么要try catch
         try {
-            return Component.translatableWithFallback(key, language.get(key), args).setStyle(style);
+            return Component.translatableWithFallback(key, text, args).setStyle(style);
         } catch (ClassCastException | NullPointerException e) {
             GcaExtension.LOGGER.error(e.getMessage(), e);
             return Component.translatable(key, args);
@@ -58,9 +63,14 @@ public class ComponentHelper {
     }
 
     public static void updateLanguage(String lang) {
-        ComponentHelper.lang = lang;
+        if (en_us.isEmpty()) {
+            String path = String.format("assets/%s/lang/%s.json", GcaExtension.MOD_ID, "en_us");
+            Map<String, String> translations = Translations.getTranslationFromResourcePath(path);
+            en_us.putAll(translations);
+        }
         String path = String.format("assets/%s/lang/%s.json", GcaExtension.MOD_ID, lang);
-        Map<String, String> translations = Translations.getTranslationFromResourcePath(path);
+        Map<String, String> translations = "en_us".equals(lang) ? en_us : Translations.getTranslationFromResourcePath(path);
+        ComponentHelper.lang = lang;
         language.clear();
         language.putAll(translations);
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
@@ -30,9 +30,6 @@ public class ComponentHelper {
     public static Component tr(String key, @Nullable TextColor color, Style style, Object... args) {
         if (color != null) style = style.withColor(color);
         String text = language.get(key);
-        if (text == null) {
-            text = en_us.get(key);
-        }
         return Component.translatableWithFallback(key, text, args).setStyle(style);
     }
 

--- a/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/api/tools/text/ComponentHelper.java
@@ -68,11 +68,15 @@ public class ComponentHelper {
             Map<String, String> translations = Translations.getTranslationFromResourcePath(path);
             en_us.putAll(translations);
         }
-        String path = String.format("assets/%s/lang/%s.json", GcaExtension.MOD_ID, lang);
-        Map<String, String> translations = "en_us".equals(lang) ? en_us : Translations.getTranslationFromResourcePath(path);
-        ComponentHelper.lang = lang;
         language.clear();
-        language.putAll(translations);
+        language.putAll(en_us);
+        ComponentHelper.lang = lang;
+        if (!"en_us".equals(lang)) {
+            String path = String.format("assets/%s/lang/%s.json", GcaExtension.MOD_ID, lang);
+            Map<String, String> translations = Translations.getTranslationFromResourcePath(path);
+            language.clear();
+            language.putAll(translations);
+        }
     }
 
     public static Map<String, String> fetchLanguage(String lang) {

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/EntityPlayerMPFakeMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/EntityPlayerMPFakeMixin.java
@@ -1,16 +1,24 @@
 package dev.dubhe.gugle.carpet.mixin;
 
 import carpet.patches.EntityPlayerMPFake;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.authlib.GameProfile;
 import dev.dubhe.gugle.carpet.GcaSetting;
 import dev.dubhe.gugle.carpet.tools.player.FakePlayerAutoReplaceTool;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//#if MC < 12109
+import java.util.Optional;
+//#else
+//$$ import java.util.UUID;
+//#endif
 //#if MC >= 12104
 //$$ import dev.dubhe.gugle.carpet.util.BotUtil;
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -44,6 +52,22 @@ public abstract class EntityPlayerMPFakeMixin extends ServerPlayer {
     //$$ @Inject(method = "isSpawningPlayer", at = @At("RETURN"), cancellable = true, remap = false)
     //$$ private static void isSpawningPlayer(String username, CallbackInfoReturnable<Boolean> cir) {
     //$$     cir.setReturnValue(cir.getReturnValue() && BotUtil.isGcaSpawningBot(username));
+    //$$ }
+    //#endif
+
+    //#if MC < 12109
+    @Nullable
+    @WrapOperation(method = "createFake", at = @At(value = "INVOKE", target = "Ljava/util/Optional;orElse(Ljava/lang/Object;)Ljava/lang/Object;"))
+    private static <T> T useOfflineUUID(Optional<T> instance, T other, Operation<T> original) {
+        if (GcaSetting.fakePlayerForceOfflineUUID) return null;
+        return original.call(instance, other);
+    }
+    //#else
+    //$$ @Nullable
+    //$$ @WrapOperation(method = "createFake", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/OldUsersConverter;convertMobOwnerIfNecessary(Lnet/minecraft/server/MinecraftServer;Ljava/lang/String;)Ljava/util/UUID;"))
+    //$$ private static UUID useOfflineUUID(MinecraftServer minecraftServer, String string, Operation<UUID> original) {
+    //$$     if (GcaSetting.fakePlayerForceOfflineUUID) return null;
+    //$$     return original.call(minecraftServer, string);
     //$$ }
     //#endif
 }

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
@@ -38,13 +38,6 @@ import java.util.function.Consumer;
 //$$ import net.minecraft.util.RandomSource;
 //#endif
 
-//#if MC>=12102
-//$$ import net.minecraft.world.InteractionResult;
-//#else
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
-//#endif
-
 @Mixin(ItemStack.class)
 abstract class ItemStackMixin {
     //#if MC>=12005
@@ -55,29 +48,6 @@ abstract class ItemStackMixin {
         //#endif
     PatchedDataComponentMap components;
     //#endif
-
-
-//    @Inject(method = "use", at = @At("HEAD"))
-//    private void use(Level level, Player player, InteractionHand usedHand, CallbackInfoReturnable<
-//        //#if MC>=12102
-//        //$$ InteractionResult
-//        //#else
-//        InteractionResultHolder<ItemStack>
-//        //#endif
-//        > cir) {
-//        if (GcaSetting.fakePlayerAutoReplenishment && player instanceof EntityPlayerMPFake fakePlayer) {
-//            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, usedHand);
-//        }
-//    }
-//
-//    @WrapOperation(method = "useOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;useOn(Lnet/minecraft/world/item/context/UseOnContext;)Lnet/minecraft/world/InteractionResult;"))
-//    private InteractionResult useOn(Item item, UseOnContext context, Operation<InteractionResult> original) {
-//        InteractionResult call = original.call(item, context);
-//        if (GcaSetting.fakePlayerAutoReplenishment && context.getPlayer() instanceof EntityPlayerMPFake fakePlayer) {
-//            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, context.getHand());
-//        }
-//        return call;
-//    }
 
     //#if MC>=12005
     @WrapOperation(method = "hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V", at = @At(value = "INVOKE", target =

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ItemStackMixin.java
@@ -5,17 +5,12 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.dubhe.gugle.carpet.GcaSetting;
 import dev.dubhe.gugle.carpet.tools.player.FakePlayerAutoReplaceTool;
-import dev.dubhe.gugle.carpet.tools.player.FakePlayerAutoReplenishment;
 
 import dev.dubhe.gugle.carpet.tools.player.FakePlayerNotification;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -62,27 +57,27 @@ abstract class ItemStackMixin {
     //#endif
 
 
-    @Inject(method = "use", at = @At("HEAD"))
-    private void use(Level level, Player player, InteractionHand usedHand, CallbackInfoReturnable<
-        //#if MC>=12102
-        //$$ InteractionResult
-        //#else
-        InteractionResultHolder<ItemStack>
-        //#endif
-        > cir) {
-        if (GcaSetting.fakePlayerAutoReplenishment && player instanceof EntityPlayerMPFake fakePlayer) {
-            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, usedHand);
-        }
-    }
-
-    @WrapOperation(method = "useOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;useOn(Lnet/minecraft/world/item/context/UseOnContext;)Lnet/minecraft/world/InteractionResult;"))
-    private InteractionResult useOn(Item item, UseOnContext context, Operation<InteractionResult> original) {
-        InteractionResult call = original.call(item, context);
-        if (GcaSetting.fakePlayerAutoReplenishment && context.getPlayer() instanceof EntityPlayerMPFake fakePlayer) {
-            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, context.getHand());
-        }
-        return call;
-    }
+//    @Inject(method = "use", at = @At("HEAD"))
+//    private void use(Level level, Player player, InteractionHand usedHand, CallbackInfoReturnable<
+//        //#if MC>=12102
+//        //$$ InteractionResult
+//        //#else
+//        InteractionResultHolder<ItemStack>
+//        //#endif
+//        > cir) {
+//        if (GcaSetting.fakePlayerAutoReplenishment && player instanceof EntityPlayerMPFake fakePlayer) {
+//            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, usedHand);
+//        }
+//    }
+//
+//    @WrapOperation(method = "useOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;useOn(Lnet/minecraft/world/item/context/UseOnContext;)Lnet/minecraft/world/InteractionResult;"))
+//    private InteractionResult useOn(Item item, UseOnContext context, Operation<InteractionResult> original) {
+//        InteractionResult call = original.call(item, context);
+//        if (GcaSetting.fakePlayerAutoReplenishment && context.getPlayer() instanceof EntityPlayerMPFake fakePlayer) {
+//            FakePlayerAutoReplenishment.autoReplenishment(fakePlayer, context.getHand());
+//        }
+//        return call;
+//    }
 
     //#if MC>=12005
     @WrapOperation(method = "hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V", at = @At(value = "INVOKE", target =

--- a/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlayerGameModeMixin.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/mixin/ServerPlayerGameModeMixin.java
@@ -1,0 +1,39 @@
+package dev.dubhe.gugle.carpet.mixin;
+
+import carpet.patches.EntityPlayerMPFake;
+import dev.dubhe.gugle.carpet.GcaSetting;
+import dev.dubhe.gugle.carpet.tools.player.FakePlayerAutoReplenishment;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerPlayerGameMode;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerGameMode.class)
+public class ServerPlayerGameModeMixin {
+
+    @Inject(method = "useItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;use(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/InteractionResult" +
+        //#if MC < 12102
+        "Holder" +
+        //#endif
+        ";"))
+    private void useItem(ServerPlayer serverPlayer, Level level, ItemStack itemStack, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
+        if (GcaSetting.fakePlayerAutoReplenishment && serverPlayer instanceof EntityPlayerMPFake) {
+            FakePlayerAutoReplenishment.autoReplenishment(serverPlayer, hand);
+        }
+    }
+
+    @Inject(method = "useItemOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;copy()Lnet/minecraft/world/item/ItemStack;", shift = At.Shift.AFTER))
+    private void useItemOn(ServerPlayer serverPlayer, Level level, ItemStack itemStack, InteractionHand hand, BlockHitResult blockHitResult, CallbackInfoReturnable<InteractionResult> cir) {
+        if (GcaSetting.fakePlayerAutoReplenishment && serverPlayer instanceof EntityPlayerMPFake) {
+            FakePlayerAutoReplenishment.autoReplenishment(serverPlayer, hand);
+        }
+
+    }
+}

--- a/src/main/java/dev/dubhe/gugle/carpet/settings/package-info.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/settings/package-info.java
@@ -1,9 +1,0 @@
-@FieldsAreNonnullByDefault
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
-package dev.dubhe.gugle.carpet.settings;
-
-import dev.dubhe.gugle.carpet.api.annotations.FieldsAreNonnullByDefault;
-import dev.dubhe.gugle.carpet.api.annotations.MethodsReturnNonnullByDefault;
-
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/tools/player/FakePlayerAutoReplaceTool.java
@@ -87,7 +87,7 @@ public class FakePlayerAutoReplaceTool {
 
     private static Predicate<ItemStack> itemReplacePredicate(Item item) {
         boolean keepTool = "keep".equals(GcaSetting.fakePlayerAutoReplaceTool);
-        return itemStack -> itemStack.getItem().getClass() == item.getClass() &&
+        return itemStack -> itemStack.is(item) &&
             ((!keepTool && !InventoryUtil.hasMendingEnchant(itemStack)) ||
                 itemStack.getMaxDamage() - itemStack.getDamageValue() > 10);
     }

--- a/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
+++ b/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
@@ -2,6 +2,7 @@ package dev.dubhe.gugle.carpet.util;
 
 import carpet.CarpetSettings;
 import com.mojang.authlib.GameProfile;
+import dev.dubhe.gugle.carpet.GcaSetting;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.players.GameProfileCache;
@@ -19,15 +20,17 @@ public class GameProfileUtil {
 
     @Nullable
     public static GameProfile getGameProfile(MinecraftServer server, final String name) {
-        GameProfileCache.setUsesAuthentication(false);
         GameProfile gameprofile = null;
-        try {
-            GameProfileCache cache = server.getProfileCache();
-            if (cache != null) {
-                gameprofile = cache.get(name).orElse(null);
+        if (!GcaSetting.fakePlayerForceOfflineUUID) {
+            GameProfileCache.setUsesAuthentication(false);
+            try {
+                GameProfileCache cache = server.getProfileCache();
+                if (cache != null) {
+                    gameprofile = cache.get(name).orElse(null);
+                }
+            } finally {
+                GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());
             }
-        } finally {
-            GameProfileCache.setUsesAuthentication(server.isDedicatedServer() && server.usesAuthentication());
         }
         if (gameprofile == null && CarpetSettings.allowSpawningOfflinePlayers) {
             gameprofile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(name), name);

--- a/src/main/resources/assets/gca/lang/en_us.json
+++ b/src/main/resources/assets/gca/lang/en_us.json
@@ -33,7 +33,7 @@
   "carpet.rule.fakePlayerAutoReplaceTool.desc": "Make fake player to auto replace damaged tool",
 
   "carpet.rule.fakePlayerToolDamagedNotification.name": "Fake Player Tool Damaged Notification",
-  "carpet.rule.fakePlayerToolDamagedNotification.desc": "Broadcast a server-wide message when a fake player’s tool breaks or when restocking fails",
+  "carpet.rule.fakePlayerToolDamagedNotification.desc": "Broadcast a server-wide message when a fake player’s tool breaks or when restocking fails. (May cause message spam)",
 
   "carpet.rule.betterFenceGatePlacement.name": "Better Fence Gate Placement",
   "carpet.rule.betterFenceGatePlacement.desc": "Make the placed fence gate have the same block status as the fence gate you clicked",

--- a/src/main/resources/assets/gca/lang/en_us.json
+++ b/src/main/resources/assets/gca/lang/en_us.json
@@ -17,6 +17,9 @@
   "carpet.rule.fakePlayerResident.name": "Fake Player Resident",
   "carpet.rule.fakePlayerResident.desc": "Keep the fake player when exiting the level",
 
+  "carpet.rule.fakePlayerForceOfflineUUID.name": "Fake Player Force Offline UUID",
+  "carpet.rule.fakePlayerForceOfflineUUID.desc": "Force fake players to use offline UUIDs. (allowSpawningOfflinePlayers must be set to true)",
+
   "carpet.rule.fakePlayerReloadAction.name": "Fake Player Reload Action",
   "carpet.rule.fakePlayerReloadAction.desc": "Keep the fake player action when exiting the level",
 

--- a/src/main/resources/assets/gca/lang/zh_cn.json
+++ b/src/main/resources/assets/gca/lang/zh_cn.json
@@ -33,7 +33,7 @@
   "carpet.rule.fakePlayerAutoReplaceTool.desc": "让假人自动切换损坏的工具",
 
   "carpet.rule.fakePlayerToolDamagedNotification.name": "假人工具损坏通知",
-  "carpet.rule.fakePlayerToolDamagedNotification.desc": "假人工具损坏或补货失败后发送一条全服广播",
+  "carpet.rule.fakePlayerToolDamagedNotification.desc": "假人工具损坏或补货失败后发送一条全服广播(可能刷屏)",
 
   "carpet.rule.betterFenceGatePlacement.name": "更好的栅栏门放置",
   "carpet.rule.betterFenceGatePlacement.desc": "让放置的栅栏门与你点击的栅栏门拥有相同的方块状态",

--- a/src/main/resources/assets/gca/lang/zh_cn.json
+++ b/src/main/resources/assets/gca/lang/zh_cn.json
@@ -14,6 +14,9 @@
   "carpet.rule.openFakePlayerEnderChest.name": "假人末影箱",
   "carpet.rule.openFakePlayerEnderChest.desc": "允许玩家打开假人末影箱",
 
+  "carpet.rule.fakePlayerForceOfflineUUID.name": "假人使用离线UUID",
+  "carpet.rule.fakePlayerForceOfflineUUID.desc": "假人强制使用离线UUID. (allowSpawningOfflinePlayers必须为true)",
+
   "carpet.rule.fakePlayerResident.name": "假人驻留",
   "carpet.rule.fakePlayerResident.desc": "退出存档时保留假人",
 

--- a/src/main/resources/gca.mixins.json
+++ b/src/main/resources/gca.mixins.json
@@ -30,6 +30,7 @@
     "ServerGamePacketListenerImplMixin",
     "ServerLevelMixin",
     "ServerPlaceRecipeMixin",
+    "ServerPlayerGameModeMixin",
     "ServerPlayerMixin",
     "SignBlockMixin",
     "SlotMixin",

--- a/versions/1.21.9/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
+++ b/versions/1.21.9/src/main/java/dev/dubhe/gugle/carpet/util/GameProfileUtil.java
@@ -2,6 +2,7 @@ package dev.dubhe.gugle.carpet.util;
 
 import carpet.CarpetSettings;
 import com.mojang.authlib.GameProfile;
+import dev.dubhe.gugle.carpet.GcaSetting;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.players.OldUsersConverter;
@@ -13,9 +14,11 @@ import java.util.concurrent.CompletableFuture;
 public class GameProfileUtil {
 
     public static GameProfile getGameProfile(MinecraftServer server, final String name) {
-        server.services().nameToIdCache().resolveOfflineUsers(false);
-
-        UUID uuid = OldUsersConverter.convertMobOwnerIfNecessary(server, name);
+        UUID uuid = null;
+        if (!GcaSetting.fakePlayerForceOfflineUUID) {
+            server.services().nameToIdCache().resolveOfflineUsers(false);
+            uuid = OldUsersConverter.convertMobOwnerIfNecessary(server, name);
+        }
         if (uuid == null && CarpetSettings.allowSpawningOfflinePlayers) {
             server.services().nameToIdCache().resolveOfflineUsers(server.isDedicatedServer() && server.usesAuthentication());
             uuid = UUIDUtil.createOfflinePlayerUUID(name);


### PR DESCRIPTION
- 使用`en_us`作为i18n默认文本
- 修改工具补货的条件以适配高版本
  - 目前为补充相同物品而不是类似物品
- 修改物品补货的时机, 更早进行补货以适配多种使用情况
  - Fixed #158
 - 更新依赖库版本
 - 新增功能`假人使用离线UUID`(`fakePlayerForceOfflineUUID`)
   - 需要`allowSpawningOfflinePlayers`为true, 否则无法召唤假人